### PR TITLE
Method based routing

### DIFF
--- a/celeritytest/celeritytest_test.go
+++ b/celeritytest/celeritytest_test.go
@@ -29,7 +29,7 @@ func TestPost(t *testing.T) {
 		return c.R(map[string]string{"param1": "123"})
 	})
 
-	r, err := Post(s, "/foo", nil)
+	r, err := Get(s, "/foo")
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -41,7 +41,7 @@ func TestPost(t *testing.T) {
 
 func TestRequest(t *testing.T) {
 	s := celerity.New()
-	s.Route(celerity.GET, "/foo", func(c celerity.Context) celerity.Response {
+	s.Route(celerity.POST, "/foo", func(c celerity.Context) celerity.Response {
 		req := struct {
 			Param1 string `json:"param1"`
 		}{}
@@ -66,7 +66,7 @@ func TestRequest(t *testing.T) {
 
 func TestHeaders(t *testing.T) {
 	s := celerity.New()
-	s.Route(celerity.GET, "/foo", func(c celerity.Context) celerity.Response {
+	s.Route(celerity.POST, "/foo", func(c celerity.Context) celerity.Response {
 		req := struct {
 			Param1 string `json:"param1"`
 		}{Param1: c.Header("Test-Header")}

--- a/route.go
+++ b/route.go
@@ -12,7 +12,7 @@ type Route struct {
 type RouteHandler func(Context) Response
 
 // Match - Matches the routes path against the incomming url
-func (r *Route) Match(path string) bool {
+func (r *Route) Match(method, path string) bool {
 	ok, xtra := r.Path.Match(path)
-	return (ok && xtra == "")
+	return (ok && xtra == "" && method == r.Method)
 }

--- a/route_test.go
+++ b/route_test.go
@@ -5,13 +5,23 @@ import "testing"
 func TestRouteMatch(t *testing.T) {
 	{
 		r := Route{
-			Path: "/users",
+			Method: GET,
+			Path:   "/users",
 		}
-		if !r.Match("/users") {
+		if !r.Match(GET, "/users") {
 			t.Error("Did not match valid path")
 		}
-		if r.Match("/bad") {
+		if r.Match(GET, "/bad") {
 			t.Error("Did match invalid path")
+		}
+	}
+	{
+		r := Route{
+			Method: POST,
+			Path:   "/users",
+		}
+		if r.Match(GET, "/users") {
+			t.Error("should not match incorrect method")
 		}
 	}
 }

--- a/router.go
+++ b/router.go
@@ -1,18 +1,22 @@
 package celerity
 
+import "net/http"
+
 var (
-	// GET - GET verb for HTTP requests
+	// GET verb for HTTP requests
 	GET = "GET"
-	// POST - POST verb for HTTP request
+	// POST verb for HTTP request
 	POST = "POST"
-	// PUT - PUT verb for HTTP request
+	// PUT verb for HTTP request
 	PUT = "POST"
-	// DELETE - DELETE verb for HTTP request
+	// DELETE verb for HTTP request
 	DELETE = "POST"
+	// ANY can be used to match any method
+	ANY = "*"
 )
 
-//MiddlewareHandler - A middleware function that can be used in scopes and
-//routes
+//MiddlewareHandler is a function that can be used in scopes and
+//routes to transform the context before the route is processed.
 type MiddlewareHandler func(RouteHandler) RouteHandler
 
 // Router - The server router stores all routes, groups, and determines what to
@@ -29,8 +33,8 @@ func NewRouter() *Router {
 }
 
 // Handle - Process the inccomming URL and execute the first matching route
-func (r *Router) Handle(c Context, path string) Response {
-	return r.Root.Handle(c, path)
+func (r *Router) Handle(c Context, req *http.Request) Response {
+	return r.Root.Handle(c, req)
 }
 
 // Route - Create a route on the root scope

--- a/server.go
+++ b/server.go
@@ -23,7 +23,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	c := NewContext()
 	c.Request = r
 	c.SetQueryParamsFromURL(r.URL)
-	resp := s.Router.Handle(c, r.URL.Path)
+	resp := s.Router.Handle(c, r)
 	b, err := s.ResponseAdapter.Process(c, resp)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/server_test.go
+++ b/server_test.go
@@ -118,7 +118,7 @@ func TestNotFound(t *testing.T) {
 
 func TestDataExtration(t *testing.T) {
 	server := New()
-	server.Router.Route("GET", "/foo", func(c Context) Response {
+	server.Router.Route(POST, "/foo", func(c Context) Response {
 		req := struct {
 			Name string `json:"name"`
 		}{}


### PR DESCRIPTION
Routing should obey the http method in the request. Previously the
method was ignored and route matching was done strictly on path. This
has been changed so that a route no longer matches if the http method
verb is not correct. This will cause URLs hit with a method different
from what is specified in the routes to return a 404 error.

This changed forced a change to the scope and router API. The handle
functions now accept the http.Request instead of a path string.
Middleware and the testing package were updated to compensate.

Resolves #10