### PR TITLE
celeritytest: Value extraction

### DIFF
--- a/celeritytest/response.go
+++ b/celeritytest/response.go
@@ -85,3 +85,8 @@ func (r *Response) ExtractAt(path string, obj interface{}) error {
 	raw := gjson.Get(r.Data, path).Raw
 	return json.Unmarshal([]byte(raw), &obj)
 }
+
+// GetResult returns a result object at a given path.
+func (r *Response) GetResult(path string) gjson.Result {
+	return gjson.Get(r.Data, path)
+}

--- a/celeritytest/response_test.go
+++ b/celeritytest/response_test.go
@@ -121,3 +121,15 @@ func TestExtractAt(t *testing.T) {
 		t.Error("values not extracted properly")
 	}
 }
+
+func TestGetResult(t *testing.T) {
+	if mockResponse.GetResult("success").Bool() != true {
+		t.Error("bool value not returned correctly.")
+	}
+	if mockResponse.GetResult("data.people.0.firstName").String() != "Alice" {
+		t.Error("string value not returned correctly.")
+	}
+	if mockResponse.GetResult("data.people.1.age").Int() != 21 {
+		t.Error("int value not returned correctly.")
+	}
+}


### PR DESCRIPTION
Alongside the "assert" methods on the celeritytest.Response, methods are
needed to extract individual values directly from the response data.

Instead of creating functions for all the possible data types the
gjson.Result is exposed via a GetResult function.

Resolves #11