### PR TITLE
HTTP Method Route Aliasing

### DIFF
--- a/middleware/aegis_test.go
+++ b/middleware/aegis_test.go
@@ -19,7 +19,7 @@ func (a *MockAegisAdapter) ValidateSession(c celerity.Context, token string) boo
 func TestSessionValidation(t *testing.T) {
 	server := celerity.New()
 
-	server.Router.Route("GET", "/foo", func(c celerity.Context) celerity.Response {
+	server.GET("/foo", func(c celerity.Context) celerity.Response {
 		return c.R(nil)
 	})
 

--- a/middleware/json_heaers_test.go
+++ b/middleware/json_heaers_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestJSONHeaders(t *testing.T) {
 	server := celerity.New()
-	server.Router.Route("GET", "/foo", func(c celerity.Context) celerity.Response {
+	server.GET("/foo", func(c celerity.Context) celerity.Response {
 		return c.R(nil)
 	})
 

--- a/router.go
+++ b/router.go
@@ -8,7 +8,9 @@ var (
 	// POST verb for HTTP request
 	POST = "POST"
 	// PUT verb for HTTP request
-	PUT = "POST"
+	PUT = "PUT"
+	// PATCH verb for HTTP requests
+	PATCH = "PATCH"
 	// DELETE verb for HTTP request
 	DELETE = "POST"
 	// ANY can be used to match any method
@@ -35,9 +37,4 @@ func NewRouter() *Router {
 // Handle - Process the inccomming URL and execute the first matching route
 func (r *Router) Handle(c Context, req *http.Request) Response {
 	return r.Root.Handle(c, req)
-}
-
-// Route - Create a route on the root scope
-func (r *Router) Route(method, path string, handler RouteHandler) {
-	r.Root.Route(method, path, handler)
 }

--- a/scope.go
+++ b/scope.go
@@ -29,6 +29,31 @@ func (s *Scope) Scope(path string) *Scope {
 	return ss
 }
 
+// GET creates a route for a GET method.
+func (s *Scope) GET(path string, handler RouteHandler) Route {
+	return s.Route(GET, path, handler)
+}
+
+// POST creates a route for a POST method.
+func (s *Scope) POST(path string, handler RouteHandler) Route {
+	return s.Route(POST, path, handler)
+}
+
+// PUT creates a route for a PUT method.
+func (s *Scope) PUT(path string, handler RouteHandler) Route {
+	return s.Route(PUT, path, handler)
+}
+
+// PATCH creates a route for a PATCH method.
+func (s *Scope) PATCH(path string, handler RouteHandler) Route {
+	return s.Route(PATCH, path, handler)
+}
+
+// DELETE creates a route for a DELETE method.
+func (s *Scope) DELETE(path string, handler RouteHandler) Route {
+	return s.Route(DELETE, path, handler)
+}
+
 // Route - Create a new route within the scope
 func (s *Scope) Route(method, path string, handler RouteHandler) Route {
 	r := Route{

--- a/scope_test.go
+++ b/scope_test.go
@@ -92,6 +92,69 @@ func TestMethodRouting(t *testing.T) {
 	}
 }
 
+func TestMethodAliases(t *testing.T) {
+	{
+		scope := newScope("/")
+		scope.GET("/get", func(c Context) Response {
+			return c.R("test")
+		})
+		c := NewContext()
+		req, _ := http.NewRequest(GET, "/get", nil)
+		r := scope.Handle(c, req)
+		if r.StatusCode != 200 {
+			t.Error("Non 200 response code for valid method/path")
+		}
+	}
+	{
+		scope := newScope("/")
+		scope.PUT("/put", func(c Context) Response {
+			return c.R("test")
+		})
+		c := NewContext()
+		req, _ := http.NewRequest(PUT, "/put", nil)
+		r := scope.Handle(c, req)
+		if r.StatusCode != 200 {
+			t.Error("Non 200 response code for valid method/path")
+		}
+	}
+	{
+		scope := newScope("/")
+		scope.DELETE("/delete", func(c Context) Response {
+			return c.R("test")
+		})
+		c := NewContext()
+		req, _ := http.NewRequest(DELETE, "/delete", nil)
+		r := scope.Handle(c, req)
+		if r.StatusCode != 200 {
+			t.Error("Non 200 response code for valid method/path")
+		}
+	}
+	{
+		scope := newScope("/")
+		scope.PATCH("/patch", func(c Context) Response {
+			return c.R("test")
+		})
+		c := NewContext()
+		req, _ := http.NewRequest(PATCH, "/patch", nil)
+		r := scope.Handle(c, req)
+		if r.StatusCode != 200 {
+			t.Error("Non 200 response code for valid method/path")
+		}
+	}
+	{
+		scope := newScope("/")
+		scope.POST("/post", func(c Context) Response {
+			return c.R("test")
+		})
+		c := NewContext()
+		req, _ := http.NewRequest(POST, "/post", nil)
+		r := scope.Handle(c, req)
+		if r.StatusCode != 200 {
+			t.Error("Non 200 response code for valid method/path")
+		}
+	}
+}
+
 func BenchmarkScopeRoute(b *testing.B) {
 	root := newScope("/")
 	scope := root

--- a/server.go
+++ b/server.go
@@ -61,6 +61,31 @@ func (s *Server) Route(method, path string, h RouteHandler) {
 	s.Router.Root.Route(method, path, h)
 }
 
+// GET creates a route for a GET method.
+func (s *Server) GET(path string, handler RouteHandler) Route {
+	return s.Router.Root.Route(GET, path, handler)
+}
+
+// POST creates a route for a POST method.
+func (s *Server) POST(path string, handler RouteHandler) Route {
+	return s.Router.Root.Route(POST, path, handler)
+}
+
+// PUT creates a route for a PUT method.
+func (s *Server) PUT(path string, handler RouteHandler) Route {
+	return s.Router.Root.Route(PUT, path, handler)
+}
+
+// PATCH creates a route for a PATCH method.
+func (s *Server) PATCH(path string, handler RouteHandler) Route {
+	return s.Router.Root.Route(PATCH, path, handler)
+}
+
+// DELETE creates a route for a DELETE method.
+func (s *Server) DELETE(path string, handler RouteHandler) Route {
+	return s.Router.Root.Route(DELETE, path, handler)
+}
+
 /*
 Rewrite rewrites urls based on on ruleset. The rewrite function accepts a
 RewriteRule map that shold contain matching patterns and transformed URLs. The

--- a/server_test.go
+++ b/server_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestServeHTTP(t *testing.T) {
 	server := New()
-	server.Router.Route("GET", "/foo", func(c Context) Response {
+	server.Route("GET", "/foo", func(c Context) Response {
 		return c.R(map[string]string{"test": "test"})
 	})
 
@@ -37,7 +37,7 @@ func TestServeHTTP(t *testing.T) {
 
 func TestURLParamHandling(t *testing.T) {
 	server := New()
-	server.Router.Route("GET", "/foo/:id", func(c Context) Response {
+	server.Route("GET", "/foo/:id", func(c Context) Response {
 		return c.R(map[string]interface{}{"id": c.URLParams.Int("id")})
 	})
 
@@ -63,7 +63,7 @@ func TestURLParamHandling(t *testing.T) {
 
 func TestQueryParamHandling(t *testing.T) {
 	server := New()
-	server.Router.Route("GET", "/foo", func(c Context) Response {
+	server.Route("GET", "/foo", func(c Context) Response {
 		return c.R(map[string]interface{}{"name": c.QueryParams.String("name")})
 	})
 
@@ -89,7 +89,7 @@ func TestQueryParamHandling(t *testing.T) {
 
 func TestNotFound(t *testing.T) {
 	server := New()
-	server.Router.Route("GET", "/foo/:id", func(c Context) Response {
+	server.Route("GET", "/foo/:id", func(c Context) Response {
 		return c.R(map[string]interface{}{"id": c.URLParams.Int("id")})
 	})
 
@@ -118,7 +118,7 @@ func TestNotFound(t *testing.T) {
 
 func TestRewrite(t *testing.T) {
 	server := New()
-	server.Router.Route("GET", "/users/:id/profile", func(c Context) Response {
+	server.Route("GET", "/users/:id/profile", func(c Context) Response {
 		return c.R(map[string]interface{}{"id": c.URLParams.Int("id")})
 	})
 
@@ -151,7 +151,7 @@ func TestRewrite(t *testing.T) {
 
 func TestDataExtration(t *testing.T) {
 	server := New()
-	server.Router.Route(POST, "/foo", func(c Context) Response {
+	server.Route(POST, "/foo", func(c Context) Response {
 		req := struct {
 			Name string `json:"name"`
 		}{}
@@ -183,9 +183,72 @@ func TestDataExtration(t *testing.T) {
 	res.Body.Close()
 }
 
+func TestServerMethodAliases(t *testing.T) {
+	{
+		svr := New()
+		svr.GET("/get", func(c Context) Response {
+			return c.R("test")
+		})
+		c := NewContext()
+		req, _ := http.NewRequest(GET, "/get", nil)
+		r := svr.Router.Root.Handle(c, req)
+		if r.StatusCode != 200 {
+			t.Error("Non 200 response code for valid method/path")
+		}
+	}
+	{
+		svr := New()
+		svr.PUT("/put", func(c Context) Response {
+			return c.R("test")
+		})
+		c := NewContext()
+		req, _ := http.NewRequest(PUT, "/put", nil)
+		r := svr.Router.Root.Handle(c, req)
+		if r.StatusCode != 200 {
+			t.Error("Non 200 response code for valid method/path")
+		}
+	}
+	{
+		svr := New()
+		svr.DELETE("/delete", func(c Context) Response {
+			return c.R("test")
+		})
+		c := NewContext()
+		req, _ := http.NewRequest(DELETE, "/delete", nil)
+		r := svr.Router.Root.Handle(c, req)
+		if r.StatusCode != 200 {
+			t.Error("Non 200 response code for valid method/path")
+		}
+	}
+	{
+		svr := New()
+		svr.PATCH("/patch", func(c Context) Response {
+			return c.R("test")
+		})
+		c := NewContext()
+		req, _ := http.NewRequest(PATCH, "/patch", nil)
+		r := svr.Router.Root.Handle(c, req)
+		if r.StatusCode != 200 {
+			t.Error("Non 200 response code for valid method/path")
+		}
+	}
+	{
+		svr := New()
+		svr.POST("/post", func(c Context) Response {
+			return c.R("test")
+		})
+		c := NewContext()
+		req, _ := http.NewRequest(POST, "/post", nil)
+		r := svr.Router.Root.Handle(c, req)
+		if r.StatusCode != 200 {
+			t.Error("Non 200 response code for valid method/path")
+		}
+	}
+}
+
 func BenchmarkRouteProcessing(b *testing.B) {
 	server := New()
-	server.Router.Route("GET", "/foo/:id", func(c Context) Response {
+	server.Route("GET", "/foo/:id", func(c Context) Response {
 		return c.R(map[string]interface{}{"id": c.URLParams.Int("id")})
 	})
 


### PR DESCRIPTION
Aliases for the Route function have been added to the Server and Scope.
These aliases represent the HTTP verb themselves.

    Server.GET("/users", handler)

Aliases exist for GET, POST, PUT, PATCH, DELETE.

Resolves 18