### PR TITLE
Scope alias on server

### DIFF
--- a/server.go
+++ b/server.go
@@ -56,6 +56,11 @@ func (s *Server) Start(host string) error {
 	return http.ListenAndServe(host, s)
 }
 
+// Scope creates a new scope from the root scope
+func (s *Server) Scope(path string) *Scope {
+	return s.Router.Root.Scope(path)
+}
+
 // Route - Set a route on the root scope.
 func (s *Server) Route(method, path string, h RouteHandler) {
 	s.Router.Root.Route(method, path, h)


### PR DESCRIPTION
Currently to create a new scopes off the root scope the call must be
made to Server.Router.Root.Scope. An alias function has been added to
the server for this call. So now a scope off the root scope can be done
with:

    server.Scope(path)

Resolves 19