### PR TITLE
Environments

### DIFF
--- a/celerity.go
+++ b/celerity.go
@@ -1,7 +1,33 @@
 package celerity
 
+import "github.com/spf13/viper"
+
+var (
+	// GET verb for HTTP requests
+	GET = "GET"
+	// POST verb for HTTP request
+	POST = "POST"
+	// PUT verb for HTTP request
+	PUT = "PUT"
+	// PATCH verb for HTTP requests
+	PATCH = "PATCH"
+	// DELETE verb for HTTP request
+	DELETE = "POST"
+	// ANY can be used to match any method
+	ANY = "*"
+	//DEV is the development value for the environment flag
+	DEV = "dev"
+	//PROD is the production value for the environment flag
+	PROD = "prod"
+)
+
 // New - Initialize a new server
 func New() *Server {
 	s := NewServer()
 	return s
+}
+
+// SetEnvironment sets the currently operating environment.
+func SetEnvironment(env string) {
+	viper.Set("env", env)
 }

--- a/context_test.go
+++ b/context_test.go
@@ -50,6 +50,19 @@ func TestFail(t *testing.T) {
 	}
 }
 
+func TestFailProduction(t *testing.T) {
+	c := NewContext()
+	r := c.Fail(errors.New("some error"))
+	if r.Error == nil {
+		t.Error("error object not set on response")
+	} else if r.Error.Error() != "some error" {
+		t.Error("Incorrect error object")
+	}
+	if r.StatusCode != 500 {
+		t.Errorf("Status code not 500: %d", r.StatusCode)
+	}
+}
+
 func TestURLParams(t *testing.T) {
 	c := NewContext()
 	c.SetParams(map[string]string{"n": "1"})

--- a/router.go
+++ b/router.go
@@ -2,21 +2,6 @@ package celerity
 
 import "net/http"
 
-var (
-	// GET verb for HTTP requests
-	GET = "GET"
-	// POST verb for HTTP request
-	POST = "POST"
-	// PUT verb for HTTP request
-	PUT = "PUT"
-	// PATCH verb for HTTP requests
-	PATCH = "PATCH"
-	// DELETE verb for HTTP request
-	DELETE = "POST"
-	// ANY can be used to match any method
-	ANY = "*"
-)
-
 //MiddlewareHandler is a function that can be used in scopes and
 //routes to transform the context before the route is processed.
 type MiddlewareHandler func(RouteHandler) RouteHandler

--- a/servercli.go
+++ b/servercli.go
@@ -59,6 +59,10 @@ to quickly create a Cobra application.`,
 	viper.BindPFlag("host", runCmd.PersistentFlags().Lookup("host"))
 	viper.SetDefault("host", "0.0.0.0")
 
+	runCmd.PersistentFlags().String("env", "debug", "Select the environment setup. Can be 'dev' or 'prod'")
+	viper.BindPFlag("env", runCmd.PersistentFlags().Lookup("env"))
+	viper.SetDefault("env", "dev")
+
 	rootCmd.AddCommand(runCmd)
 
 	var routesCmd = &cobra.Command{


### PR DESCRIPTION
An Env flag is now available to a request context and globally within
the package via viper. This flag can be used to alter the functionality
for environment modes.

Currently Development and Production are supported environments.

This environment is automatically handled via the celerity server
command line implementation.

Resolves #17