### PR TITLE
Request

### DIFF
--- a/context.go
+++ b/context.go
@@ -6,7 +6,9 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 
+	"github.com/google/uuid"
 	"github.com/spf13/viper"
 )
 
@@ -30,6 +32,7 @@ func NewContext() Context {
 		properties:  map[string]interface{}{},
 		Response:    NewResponse(),
 		Env:         viper.GetString("env"),
+		RequestID:   strings.Replace(uuid.New().String(), "-", "", -1),
 	}
 }
 

--- a/context_test.go
+++ b/context_test.go
@@ -16,6 +16,10 @@ func TestNewContext(t *testing.T) {
 	if c.QueryParams == nil {
 		t.Error("QueryParams not initialized")
 	}
+
+	if len(c.RequestID) != 32 {
+		t.Errorf("request id invalid: %s", c.RequestID)
+	}
 }
 
 func TestRespond(t *testing.T) {


### PR DESCRIPTION
Added UUID generation for unique requestIDs. These IDs are automatically
generated when a context is created and appended to the request output.
This is intended to be used for log tracing.

The server tests were also refactored, as they were matching the entire
response text against static text. This wont work since the requestIDs
are now randomly generated.

All the tests have been changed to use struct level validation.

Resolves #21