### PR TITLE
Partial structure based validation

### DIFF
--- a/celeritytest/response.go
+++ b/celeritytest/response.go
@@ -94,12 +94,25 @@ func (r *Response) GetResult(path string) gjson.Result {
 	return gjson.Get(r.Data, path)
 }
 
-// Validate validates the the response data against a validation structure
+// Validate validates the response data against a validation structure
 func (r *Response) Validate(vs interface{}) error {
 	if r.validator == nil {
 		r.validator = validator.New()
 	}
-	err := json.Unmarshal([]byte(r.Data), vs)
+	err := r.Extract(&vs)
+	if err != nil {
+		return err
+	}
+	return r.validator.Struct(vs)
+}
+
+// ValidateAt validates a portion of the the response data against a
+// validation structure.
+func (r *Response) ValidateAt(path string, vs interface{}) error {
+	if r.validator == nil {
+		r.validator = validator.New()
+	}
+	err := r.ExtractAt(path, &vs)
 	if err != nil {
 		return err
 	}

--- a/celeritytest/response_test.go
+++ b/celeritytest/response_test.go
@@ -135,18 +135,32 @@ func TestGetResult(t *testing.T) {
 }
 
 func TestValidation(t *testing.T) {
-	s := struct {
-		Success bool   `json:"success" validate:"required"`
-		Error   string `json:"error" validate:"isdefault"`
-		Data    struct {
+	{
+		s := struct {
+			Success bool   `json:"success" validate:"required"`
+			Error   string `json:"error" validate:"isdefault"`
+			Data    struct {
+				People []struct {
+					FirstName string `json:"firstName" validate:"required,alpha"`
+					LastName  string `json:"lastName" validate:"required,alpha"`
+					Age       int    `json:"age" validate:"numeric,required"`
+				} `json:"people" validate:"required,len=2,dive"`
+			} `json:"data" validate:"required"`
+		}{}
+		if err := mockResponse.Validate(&s); err != nil {
+			t.Error(err.Error())
+		}
+	}
+	{
+		s := struct {
 			People []struct {
 				FirstName string `json:"firstName" validate:"required,alpha"`
 				LastName  string `json:"lastName" validate:"required,alpha"`
 				Age       int    `json:"age" validate:"numeric,required"`
 			} `json:"people" validate:"required,len=2,dive"`
-		} `json:"data" validate:"required"`
-	}{}
-	if err := mockResponse.Validate(&s); err != nil {
-		t.Error(err.Error())
+		}{}
+		if err := mockResponse.ValidateAt("data", &s); err != nil {
+			t.Error(err.Error())
+		}
 	}
 }


### PR DESCRIPTION
ValidateAt was added to allow validating a structure against a piece of
the response.

Internally it uses ExtractAt and the validates.

This does not currently work on array paths. The given path must be an
object.