### PR TITLE
Preroute Middleware

### DIFF
--- a/celerity.go
+++ b/celerity.go
@@ -13,6 +13,8 @@ var (
 	PATCH = "PATCH"
 	// DELETE verb for HTTP request
 	DELETE = "POST"
+	// OPTIONS verb for HTTP request
+	OPTIONS = "OPTIONS"
 	// ANY can be used to match any method
 	ANY = "*"
 	//DEV is the development value for the environment flag

--- a/celeritytest/celeritytest.go
+++ b/celeritytest/celeritytest.go
@@ -52,44 +52,22 @@ type RequestOptions struct {
 // by the package level Post function in cases where you want to make a one off
 // request.
 func (ts *TestServer) Post(path string, data []byte) (*Response, error) {
-	httpServer := httptest.NewServer(ts.Server)
-	defer httpServer.Close()
-
-	res, err := http.Post(httpServer.URL+path, "application/json", bytes.NewBuffer(data))
-	if err != nil {
-		return nil, err
+	reqOpts := RequestOptions{
+		Method: celerity.POST,
+		Path:   path,
 	}
-	bbody, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		return nil, err
-	}
-	response := &Response{
-		StatusCode: res.StatusCode,
-		Data:       string(bbody),
-	}
-	return response, err
+	return ts.Request(reqOpts)
 }
 
 // Get - Makes a GET request against the test server. This function is called
 // by the package level Get function in cases where you want to make a one off
 // request.
 func (ts *TestServer) Get(path string) (*Response, error) {
-	httpServer := httptest.NewServer(ts.Server)
-	defer httpServer.Close()
-
-	res, err := http.Get(httpServer.URL + path)
-	if err != nil {
-		return nil, err
+	reqOpts := RequestOptions{
+		Method: celerity.GET,
+		Path:   path,
 	}
-	bbody, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		return nil, err
-	}
-	response := &Response{
-		StatusCode: res.StatusCode,
-		Data:       string(bbody),
-	}
-	return response, err
+	return ts.Request(reqOpts)
 }
 
 // Request makes a request against the test server. This function is called by
@@ -120,6 +98,7 @@ func (ts *TestServer) Request(reqOpts RequestOptions) (*Response, error) {
 	response := &Response{
 		StatusCode: res.StatusCode,
 		Data:       string(bbody),
+		Header:     res.Header,
 	}
 	return response, err
 }

--- a/celeritytest/response.go
+++ b/celeritytest/response.go
@@ -2,6 +2,7 @@ package celeritytest
 
 import (
 	"encoding/json"
+	"net/http"
 
 	validator "gopkg.in/go-playground/validator.v9"
 
@@ -15,6 +16,7 @@ type Response struct {
 	StatusCode int
 	Data       string
 	validator  *validator.Validate
+	Header     http.Header
 }
 
 // AssertString checks a string value in the returning JSON at a given path.

--- a/context.go
+++ b/context.go
@@ -22,6 +22,7 @@ type Context struct {
 	properties  map[string]interface{}
 	Response    Response
 	Env         string
+	ScopedPath  string
 }
 
 // NewContext Create a new context object
@@ -34,6 +35,14 @@ func NewContext() Context {
 		Env:         viper.GetString("env"),
 		RequestID:   strings.Replace(uuid.New().String(), "-", "", -1),
 	}
+}
+
+// RequestContext - Creates a new context and sets its request.
+func RequestContext(r *http.Request) Context {
+	c := NewContext()
+	c.Request = r
+	c.ScopedPath = r.URL.Path
+	return c
 }
 
 // Header Request headers

--- a/middleware/json_headers.go
+++ b/middleware/json_headers.go
@@ -6,7 +6,7 @@ import "github.com/5Sigma/celerity"
 func JSONMiddleware() celerity.MiddlewareHandler {
 	return func(next celerity.RouteHandler) celerity.RouteHandler {
 		return func(c celerity.Context) celerity.Response {
-			c.Response.Headers["Content-Type"] = "application/json"
+			c.Response.Header.Set("Content-Type", "application/json")
 			return next(c)
 		}
 	}

--- a/response.go
+++ b/response.go
@@ -11,14 +11,14 @@ type Response struct {
 	Data       interface{}
 	Error      error
 	Meta       map[string]interface{}
-	Headers    map[string]string
+	Header     http.Header
 }
 
 // NewResponse - Create a new response object
 func NewResponse() Response {
 	return Response{
-		Meta:    map[string]interface{}{},
-		Headers: map[string]string{},
+		Meta:   map[string]interface{}{},
+		Header: http.Header{},
 	}
 }
 

--- a/router.go
+++ b/router.go
@@ -21,5 +21,5 @@ func NewRouter() *Router {
 
 // Handle - Process the inccomming URL and execute the first matching route
 func (r *Router) Handle(c Context, req *http.Request) Response {
-	return r.Root.Handle(c, req)
+	return r.Root.Handle(c)
 }

--- a/scope_test.go
+++ b/scope_test.go
@@ -54,7 +54,8 @@ func TestScopeHandle(t *testing.T) {
 		})
 		c := NewContext()
 		req, _ := http.NewRequest(GET, "/users", nil)
-		r := scope.Handle(c, req)
+		c.Request = req
+		r := scope.Handle(c)
 		v, ok := r.Data.(string)
 		if !ok {
 			t.Error("Data result incorrect type")
@@ -73,7 +74,8 @@ func TestMethodRouting(t *testing.T) {
 		})
 		c := NewContext()
 		req, _ := http.NewRequest(GET, "/users", nil)
-		r := scope.Handle(c, req)
+		c.Request = req
+		r := scope.Handle(c)
 		if r.StatusCode != 200 {
 			t.Error("Non 200 response code for valid method/path")
 		}
@@ -85,7 +87,8 @@ func TestMethodRouting(t *testing.T) {
 		})
 		c := NewContext()
 		req, _ := http.NewRequest(GET, "/users", nil)
-		r := scope.Handle(c, req)
+		c.Request = req
+		r := scope.Handle(c)
 		if r.StatusCode != 404 {
 			t.Error("Non 404 response code for invalid method/path")
 		}
@@ -100,7 +103,8 @@ func TestMethodAliases(t *testing.T) {
 		})
 		c := NewContext()
 		req, _ := http.NewRequest(GET, "/get", nil)
-		r := scope.Handle(c, req)
+		c.Request = req
+		r := scope.Handle(c)
 		if r.StatusCode != 200 {
 			t.Error("Non 200 response code for valid method/path")
 		}
@@ -112,7 +116,8 @@ func TestMethodAliases(t *testing.T) {
 		})
 		c := NewContext()
 		req, _ := http.NewRequest(PUT, "/put", nil)
-		r := scope.Handle(c, req)
+		c.Request = req
+		r := scope.Handle(c)
 		if r.StatusCode != 200 {
 			t.Error("Non 200 response code for valid method/path")
 		}
@@ -124,7 +129,8 @@ func TestMethodAliases(t *testing.T) {
 		})
 		c := NewContext()
 		req, _ := http.NewRequest(DELETE, "/delete", nil)
-		r := scope.Handle(c, req)
+		c.Request = req
+		r := scope.Handle(c)
 		if r.StatusCode != 200 {
 			t.Error("Non 200 response code for valid method/path")
 		}
@@ -136,7 +142,8 @@ func TestMethodAliases(t *testing.T) {
 		})
 		c := NewContext()
 		req, _ := http.NewRequest(PATCH, "/patch", nil)
-		r := scope.Handle(c, req)
+		c.Request = req
+		r := scope.Handle(c)
 		if r.StatusCode != 200 {
 			t.Error("Non 200 response code for valid method/path")
 		}
@@ -148,7 +155,8 @@ func TestMethodAliases(t *testing.T) {
 		})
 		c := NewContext()
 		req, _ := http.NewRequest(POST, "/post", nil)
-		r := scope.Handle(c, req)
+		c.Request = req
+		r := scope.Handle(c)
 		if r.StatusCode != 200 {
 			t.Error("Non 200 response code for valid method/path")
 		}
@@ -179,7 +187,8 @@ func TestScopeCollision(t *testing.T) {
 	})
 	c := NewContext()
 	req, _ := http.NewRequest(GET, "/users/get", nil)
-	r := root.Handle(c, req)
+	c.Request = req
+	r := root.Handle(c)
 	v, ok := r.Data.(string)
 	if !ok {
 		t.Error("Data result incorrect type")
@@ -205,7 +214,8 @@ func TestMiddleware(t *testing.T) {
 	})
 	c := NewContext()
 	req, _ := http.NewRequest(GET, "/middleware", nil)
-	r := root.Handle(c, req)
+	c.Request = req
+	r := root.Handle(c)
 	v, ok := r.Data.(string)
 	if !ok {
 		t.Error("Data result incorrect type")

--- a/scope_test.go
+++ b/scope_test.go
@@ -52,9 +52,8 @@ func TestScopeHandle(t *testing.T) {
 		scope.Route("GET", "/users", func(c Context) Response {
 			return c.R("test")
 		})
-		c := NewContext()
 		req, _ := http.NewRequest(GET, "/users", nil)
-		c.Request = req
+		c := RequestContext(req)
 		r := scope.Handle(c)
 		v, ok := r.Data.(string)
 		if !ok {
@@ -72,9 +71,8 @@ func TestMethodRouting(t *testing.T) {
 		scope.Route(GET, "/users", func(c Context) Response {
 			return c.R("test")
 		})
-		c := NewContext()
 		req, _ := http.NewRequest(GET, "/users", nil)
-		c.Request = req
+		c := RequestContext(req)
 		r := scope.Handle(c)
 		if r.StatusCode != 200 {
 			t.Error("Non 200 response code for valid method/path")
@@ -85,9 +83,8 @@ func TestMethodRouting(t *testing.T) {
 		scope.Route(POST, "/users", func(c Context) Response {
 			return c.R("test")
 		})
-		c := NewContext()
 		req, _ := http.NewRequest(GET, "/users", nil)
-		c.Request = req
+		c := RequestContext(req)
 		r := scope.Handle(c)
 		if r.StatusCode != 404 {
 			t.Error("Non 404 response code for invalid method/path")
@@ -101,9 +98,8 @@ func TestMethodAliases(t *testing.T) {
 		scope.GET("/get", func(c Context) Response {
 			return c.R("test")
 		})
-		c := NewContext()
 		req, _ := http.NewRequest(GET, "/get", nil)
-		c.Request = req
+		c := RequestContext(req)
 		r := scope.Handle(c)
 		if r.StatusCode != 200 {
 			t.Error("Non 200 response code for valid method/path")
@@ -114,9 +110,8 @@ func TestMethodAliases(t *testing.T) {
 		scope.PUT("/put", func(c Context) Response {
 			return c.R("test")
 		})
-		c := NewContext()
 		req, _ := http.NewRequest(PUT, "/put", nil)
-		c.Request = req
+		c := RequestContext(req)
 		r := scope.Handle(c)
 		if r.StatusCode != 200 {
 			t.Error("Non 200 response code for valid method/path")
@@ -127,9 +122,8 @@ func TestMethodAliases(t *testing.T) {
 		scope.DELETE("/delete", func(c Context) Response {
 			return c.R("test")
 		})
-		c := NewContext()
 		req, _ := http.NewRequest(DELETE, "/delete", nil)
-		c.Request = req
+		c := RequestContext(req)
 		r := scope.Handle(c)
 		if r.StatusCode != 200 {
 			t.Error("Non 200 response code for valid method/path")
@@ -140,9 +134,8 @@ func TestMethodAliases(t *testing.T) {
 		scope.PATCH("/patch", func(c Context) Response {
 			return c.R("test")
 		})
-		c := NewContext()
 		req, _ := http.NewRequest(PATCH, "/patch", nil)
-		c.Request = req
+		c := RequestContext(req)
 		r := scope.Handle(c)
 		if r.StatusCode != 200 {
 			t.Error("Non 200 response code for valid method/path")
@@ -153,9 +146,8 @@ func TestMethodAliases(t *testing.T) {
 		scope.POST("/post", func(c Context) Response {
 			return c.R("test")
 		})
-		c := NewContext()
 		req, _ := http.NewRequest(POST, "/post", nil)
-		c.Request = req
+		c := RequestContext(req)
 		r := scope.Handle(c)
 		if r.StatusCode != 200 {
 			t.Error("Non 200 response code for valid method/path")
@@ -185,9 +177,8 @@ func TestScopeCollision(t *testing.T) {
 	users.Route(GET, "/get", func(c Context) Response {
 		return c.R("test")
 	})
-	c := NewContext()
 	req, _ := http.NewRequest(GET, "/users/get", nil)
-	c.Request = req
+	c := RequestContext(req)
 	r := root.Handle(c)
 	v, ok := r.Data.(string)
 	if !ok {
@@ -212,9 +203,8 @@ func TestMiddleware(t *testing.T) {
 		}
 		return c.R("bad")
 	})
-	c := NewContext()
 	req, _ := http.NewRequest(GET, "/middleware", nil)
-	c.Request = req
+	c := RequestContext(req)
 	r := root.Handle(c)
 	v, ok := r.Data.(string)
 	if !ok {

--- a/server.go
+++ b/server.go
@@ -38,12 +38,19 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	for k, v := range c.Response.Headers {
-		w.Header().Add(k, v)
+	for k, vs := range c.Response.Header {
+		for _, v := range vs {
+			w.Header().Add(k, v)
+		}
 	}
 
 	w.WriteHeader(resp.StatusCode)
 	w.Write(b)
+}
+
+// Pre - Register prehandle middleware for the root scope.
+func (s *Server) Pre(mw MiddlewareHandler) {
+	s.Router.Root.Pre(mw)
 }
 
 // Use - Use a middleware in the root scope.

--- a/server.go
+++ b/server.go
@@ -24,12 +24,11 @@ func NewServer() *Server {
 
 // ServeHTTP - Serves the HTTP request. Complies with http.Handler interface
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	c := NewContext()
 	rewrite, rewritePath := s.RewriteRules.Match(r.URL.Path)
 	if rewrite {
 		r.URL.Path = rewritePath
 	}
-	c.Request = r
+	c := RequestContext(r)
 	c.SetQueryParamsFromURL(r.URL)
 	resp := s.Router.Handle(c, r)
 	b, err := s.ResponseAdapter.Process(c, resp)

--- a/server_test.go
+++ b/server_test.go
@@ -385,7 +385,8 @@ func TestServerMethodAliases(t *testing.T) {
 		})
 		c := NewContext()
 		req, _ := http.NewRequest(GET, "/get", nil)
-		r := svr.Router.Root.Handle(c, req)
+		c.Request = req
+		r := svr.Router.Root.Handle(c)
 		if r.StatusCode != 200 {
 			t.Error("Non 200 response code for valid method/path")
 		}
@@ -397,7 +398,8 @@ func TestServerMethodAliases(t *testing.T) {
 		})
 		c := NewContext()
 		req, _ := http.NewRequest(PUT, "/put", nil)
-		r := svr.Router.Root.Handle(c, req)
+		c.Request = req
+		r := svr.Router.Root.Handle(c)
 		if r.StatusCode != 200 {
 			t.Error("Non 200 response code for valid method/path")
 		}
@@ -409,7 +411,8 @@ func TestServerMethodAliases(t *testing.T) {
 		})
 		c := NewContext()
 		req, _ := http.NewRequest(DELETE, "/delete", nil)
-		r := svr.Router.Root.Handle(c, req)
+		c.Request = req
+		r := svr.Router.Root.Handle(c)
 		if r.StatusCode != 200 {
 			t.Error("Non 200 response code for valid method/path")
 		}
@@ -421,7 +424,8 @@ func TestServerMethodAliases(t *testing.T) {
 		})
 		c := NewContext()
 		req, _ := http.NewRequest(PATCH, "/patch", nil)
-		r := svr.Router.Root.Handle(c, req)
+		c.Request = req
+		r := svr.Router.Root.Handle(c)
 		if r.StatusCode != 200 {
 			t.Error("Non 200 response code for valid method/path")
 		}
@@ -433,7 +437,8 @@ func TestServerMethodAliases(t *testing.T) {
 		})
 		c := NewContext()
 		req, _ := http.NewRequest(POST, "/post", nil)
-		r := svr.Router.Root.Handle(c, req)
+		c.Request = req
+		r := svr.Router.Root.Handle(c)
 		if r.StatusCode != 200 {
 			t.Error("Non 200 response code for valid method/path")
 		}

--- a/server_test.go
+++ b/server_test.go
@@ -383,12 +383,11 @@ func TestServerMethodAliases(t *testing.T) {
 		svr.GET("/get", func(c Context) Response {
 			return c.R("test")
 		})
-		c := NewContext()
 		req, _ := http.NewRequest(GET, "/get", nil)
-		c.Request = req
+		c := RequestContext(req)
 		r := svr.Router.Root.Handle(c)
 		if r.StatusCode != 200 {
-			t.Error("Non 200 response code for valid method/path")
+			t.Errorf("Non 200 response code for valid method/path: %d", r.StatusCode)
 		}
 	}
 	{
@@ -396,9 +395,8 @@ func TestServerMethodAliases(t *testing.T) {
 		svr.PUT("/put", func(c Context) Response {
 			return c.R("test")
 		})
-		c := NewContext()
 		req, _ := http.NewRequest(PUT, "/put", nil)
-		c.Request = req
+		c := RequestContext(req)
 		r := svr.Router.Root.Handle(c)
 		if r.StatusCode != 200 {
 			t.Error("Non 200 response code for valid method/path")
@@ -409,9 +407,8 @@ func TestServerMethodAliases(t *testing.T) {
 		svr.DELETE("/delete", func(c Context) Response {
 			return c.R("test")
 		})
-		c := NewContext()
 		req, _ := http.NewRequest(DELETE, "/delete", nil)
-		c.Request = req
+		c := RequestContext(req)
 		r := svr.Router.Root.Handle(c)
 		if r.StatusCode != 200 {
 			t.Error("Non 200 response code for valid method/path")
@@ -422,9 +419,8 @@ func TestServerMethodAliases(t *testing.T) {
 		svr.PATCH("/patch", func(c Context) Response {
 			return c.R("test")
 		})
-		c := NewContext()
 		req, _ := http.NewRequest(PATCH, "/patch", nil)
-		c.Request = req
+		c := RequestContext(req)
 		r := svr.Router.Root.Handle(c)
 		if r.StatusCode != 200 {
 			t.Error("Non 200 response code for valid method/path")
@@ -435,9 +431,8 @@ func TestServerMethodAliases(t *testing.T) {
 		svr.POST("/post", func(c Context) Response {
 			return c.R("test")
 		})
-		c := NewContext()
 		req, _ := http.NewRequest(POST, "/post", nil)
-		c.Request = req
+		c := RequestContext(req)
 		r := svr.Router.Root.Handle(c)
 		if r.StatusCode != 200 {
 			t.Error("Non 200 response code for valid method/path")


### PR DESCRIPTION
Middleware can be used as Premiddleware that is processed as soon as the scope is matched. This middleware will be processed even if the route does not exist, as long as the scope matches the path.

This was done to provide a method for handling certain types  of middleware such as Rewrite and CORS middlewares where the route might not exist prior to the middleware's execution.