### PR TITLE
Wildcard routing

### DIFF
--- a/route_path.go
+++ b/route_path.go
@@ -25,6 +25,9 @@ func (rp RoutePath) Match(path string) (bool, string) {
 		return false, path
 	}
 	for idx, t := range rpTokens {
+		if t == "*" {
+			return true, ""
+		}
 		if t == "" {
 			continue
 		}

--- a/route_path_test.go
+++ b/route_path_test.go
@@ -56,3 +56,20 @@ func TestRoutePathGetURLParams(t *testing.T) {
 		}
 	}
 }
+
+func TestWildCardMatch(t *testing.T) {
+	{
+		var rp RoutePath = "*"
+		ok, _ := rp.Match("/some/route/to/test")
+		if !ok {
+			t.Error("wldcard path did not match")
+		}
+	}
+	{
+		var rp RoutePath = "/some/route/*"
+		ok, _ := rp.Match("/some/route/to/test")
+		if !ok {
+			t.Error("wldcard path did not match")
+		}
+	}
+}

--- a/server_test.go
+++ b/server_test.go
@@ -336,6 +336,34 @@ func TestFailResponse(t *testing.T) {
 	}
 }
 
+func TestWildcardRouting(t *testing.T) {
+	{
+		svr := New()
+		svr.GET("/get/*", func(c Context) Response {
+			return c.R("test")
+		})
+		req, _ := http.NewRequest(GET, "/get/something/cool", nil)
+		c := RequestContext(req)
+		r := svr.Router.Root.Handle(c)
+		if r.StatusCode != 200 {
+			t.Errorf("Non 200 response code for valid method/path: %d", r.StatusCode)
+		}
+	}
+
+	{
+		svr := New()
+		svr.GET("/get/*", func(c Context) Response {
+			return c.R("test")
+		})
+		req, _ := http.NewRequest(GET, "/not/something/cool", nil)
+		c := RequestContext(req)
+		r := svr.Router.Root.Handle(c)
+		if r.StatusCode == 200 {
+			t.Error("200 response code for invalid method/path")
+		}
+	}
+}
+
 func TestServerMethodAliases(t *testing.T) {
 	{
 		svr := New()


### PR DESCRIPTION
The router now supports wild card routing. A route which contains a "*"
will match any number of URL tokens after it.

A route such as:

  "/example/*"

Would match:

-  "/example/test"
-  "/example/test/1"
-  "/example/something/else"