### PR TITLE
RouteHandler recovery

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -1,7 +1,9 @@
 package celerity
 
 import (
+	"fmt"
 	"net/http"
+	"runtime/debug"
 )
 
 // Scope - A group of routes and subgroups used to represent the routing
@@ -151,6 +153,14 @@ func (s *Scope) handleWithMiddleware(c Context, middleware []MiddlewareHandler) 
 }
 
 // Handle - Handle an incomming URL
-func (s *Scope) Handle(c Context) Response {
+func (s *Scope) Handle(c Context) (res Response) {
+	defer func() {
+		if r := recover(); r != nil {
+			res = c.Fail(fmt.Errorf("%v", r))
+			if c.Env == DEV {
+				res.Data = string(debug.Stack())
+			}
+		}
+	}()
 	return s.handleWithMiddleware(c, []MiddlewareHandler{})
 }

--- a/scope_test.go
+++ b/scope_test.go
@@ -252,3 +252,21 @@ func TestUse(t *testing.T) {
 		t.Error("middleware not added to collection")
 	}
 }
+
+func TestPanicRecovery(t *testing.T) {
+	s := newScope("/")
+	s.GET("/foo", func(c Context) Response {
+		panic("uh oh")
+	})
+	{
+		req, err := http.NewRequest("GET", "http://example.com/foo", nil)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+		c := RequestContext(req)
+		r := s.Handle(c)
+		if r.StatusCode != 500 {
+			t.Errorf("status code should be 500: %d", r.StatusCode)
+		}
+	}
+}


### PR DESCRIPTION
Scopes will recover when a RouteHandler panics and present a 500 response. While in a DEV environment the data of the response will be populated will a full stack trace of the panic and the Error is populated with the panic message. 

Internally this uses Context.Fail so in PROD environments the error and data will not be present. 

Resolves #20 
