### PR TITLE
Local File Serving

### DIFF
--- a/celerity.go
+++ b/celerity.go
@@ -1,6 +1,9 @@
 package celerity
 
-import "github.com/spf13/viper"
+import (
+	"github.com/spf13/afero"
+	"github.com/spf13/viper"
+)
 
 var (
 	// GET verb for HTTP requests
@@ -21,6 +24,8 @@ var (
 	DEV = "dev"
 	//PROD is the production value for the environment flag
 	PROD = "prod"
+	// FS Filesystem interface
+	FS = afero.NewOsFs()
 )
 
 // New - Initialize a new server

--- a/context.go
+++ b/context.go
@@ -127,6 +127,13 @@ func (c *Context) Error(status int, err error) Response {
 	return c.Response
 }
 
+// File sets the response to output a file from a local filepath
+func (c *Context) File(fileroot, filepath string) Response {
+	c.Response.Filepath = filepath
+	c.Response.Fileroot = fileroot
+	return c.Response
+}
+
 // Extract - Unmarshal request data into a structure.
 func (c *Context) Extract(obj interface{}) error {
 	decoder := json.NewDecoder(bytes.NewReader(c.Body()))

--- a/fsadapter.go
+++ b/fsadapter.go
@@ -16,11 +16,18 @@ func (o *OSAdapter) RootPath(path string) afero.Fs {
 }
 
 // MEMAdapter give access to an in memory file system for testing
-type MEMAdapter struct{}
+type MEMAdapter struct {
+	MEMFS afero.Fs
+}
+
+// NewMEMAdapter creates a new in memory FS adapter for testing
+func NewMEMAdapter() *MEMAdapter {
+	mm := afero.NewMemMapFs()
+	return &MEMAdapter{mm}
+}
 
 // RootPath reutrns a filesystem with in memory access
 func (m *MEMAdapter) RootPath(path string) afero.Fs {
-	mm := afero.NewMemMapFs()
-	mm.MkdirAll(path, 0755)
-	return afero.NewBasePathFs(mm, path)
+	m.MEMFS.MkdirAll(path, 0755)
+	return afero.NewBasePathFs(m.MEMFS, path)
 }

--- a/fsadapter.go
+++ b/fsadapter.go
@@ -1,0 +1,26 @@
+package celerity
+
+import "github.com/spf13/afero"
+
+// FSAdapter is the adapter used for gaining access to the file system
+type FSAdapter interface {
+	RootPath(string) afero.Fs
+}
+
+// OSAdapter gives access to the file system
+type OSAdapter struct{}
+
+// RootPath reutrns a filesystem with OS access
+func (o *OSAdapter) RootPath(path string) afero.Fs {
+	return afero.NewBasePathFs(afero.NewOsFs(), path)
+}
+
+// MEMAdapter give access to an in memory file system for testing
+type MEMAdapter struct{}
+
+// RootPath reutrns a filesystem with in memory access
+func (m *MEMAdapter) RootPath(path string) afero.Fs {
+	mm := afero.NewMemMapFs()
+	mm.MkdirAll(path, 0755)
+	return afero.NewBasePathFs(mm, path)
+}

--- a/response.go
+++ b/response.go
@@ -12,6 +12,8 @@ type Response struct {
 	Error      error
 	Meta       map[string]interface{}
 	Header     http.Header
+	Filepath   string
+	Fileroot   string
 }
 
 // NewResponse - Create a new response object
@@ -40,4 +42,9 @@ func (r *Response) StatusText() string {
 // is not present
 func (r *Response) Success() bool {
 	return r.Error == nil
+}
+
+// IsFile returns true if the response should output a local file
+func (r *Response) IsFile() bool {
+	return (r.Filepath != "")
 }

--- a/response_test.go
+++ b/response_test.go
@@ -24,3 +24,11 @@ func TestNewErrorResponse(t *testing.T) {
 		t.Errorf("success returned true for errored response")
 	}
 }
+
+func TestIsFile(t *testing.T) {
+	r := NewResponse()
+	r.Filepath = "/test.txt"
+	if !r.IsFile() {
+		t.Error("should return true")
+	}
+}

--- a/route.go
+++ b/route.go
@@ -12,7 +12,7 @@ type Route struct {
 type RouteHandler func(Context) Response
 
 // Match - Matches the routes path against the incomming url
-func (r *Route) Match(method, path string) bool {
+func (r *Route) Match(method, path string) (bool, string) {
 	ok, xtra := r.Path.Match(path)
-	return (ok && xtra == "" && method == r.Method)
+	return (ok && method == r.Method && xtra == ""), xtra
 }

--- a/route_test.go
+++ b/route_test.go
@@ -8,10 +8,10 @@ func TestRouteMatch(t *testing.T) {
 			Method: GET,
 			Path:   "/users",
 		}
-		if !r.Match(GET, "/users") {
+		if ok, _ := r.Match(GET, "/users"); !ok {
 			t.Error("Did not match valid path")
 		}
-		if r.Match(GET, "/bad") {
+		if ok, _ := r.Match(GET, "/bad"); ok {
 			t.Error("Did match invalid path")
 		}
 	}
@@ -20,7 +20,7 @@ func TestRouteMatch(t *testing.T) {
 			Method: POST,
 			Path:   "/users",
 		}
-		if r.Match(GET, "/users") {
+		if ok, _ := r.Match(GET, "/users"); ok {
 			t.Error("should not match incorrect method")
 		}
 	}

--- a/scope.go
+++ b/scope.go
@@ -72,10 +72,8 @@ func (s *Scope) Route(method, path string, handler RouteHandler) Route {
 // ServePath serves static files at a filepath
 func (s *Scope) ServePath(path, staticpath string) {
 	s.GET(path+"/*", func(c Context) Response {
-		filepath := fmt.Sprintf("%s/%s",
-			strings.TrimRight(staticpath, "/"),
-			strings.TrimLeft(c.ScopedPath[len(path):], "/"))
-		return c.File(path, filepath)
+		path := fmt.Sprintf("/%s", strings.TrimLeft(c.ScopedPath[len(path):], "/"))
+		return c.File(staticpath, path)
 	})
 }
 

--- a/scope.go
+++ b/scope.go
@@ -80,11 +80,11 @@ func (s *Scope) ServePath(path, staticpath string) {
 
 // ServeFile serves static files at a filepath
 func (s *Scope) ServeFile(path, localpath string) {
-	fname := filepath.Base(localpath)
+	fname := "/" + filepath.Base(localpath)
 	fpath := filepath.Dir(localpath)
 
 	s.GET(path, func(c Context) Response {
-		return c.File(fname, fpath)
+		return c.File(fpath, fname)
 	})
 }
 
@@ -184,4 +184,11 @@ func (s *Scope) Handle(c Context) (res Response) {
 		}
 	}()
 	return s.handleWithMiddleware(c, []MiddlewareHandler{})
+}
+
+func fixPath(p string) string {
+	if p[0] != '/' {
+		return "/" + p
+	}
+	return p
 }

--- a/scope.go
+++ b/scope.go
@@ -3,6 +3,7 @@ package celerity
 import (
 	"fmt"
 	"net/http"
+	"path/filepath"
 	"runtime/debug"
 	"strings"
 )
@@ -74,6 +75,16 @@ func (s *Scope) ServePath(path, staticpath string) {
 	s.GET(path+"/*", func(c Context) Response {
 		path := fmt.Sprintf("/%s", strings.TrimLeft(c.ScopedPath[len(path):], "/"))
 		return c.File(staticpath, path)
+	})
+}
+
+// ServeFile serves static files at a filepath
+func (s *Scope) ServeFile(path, localpath string) {
+	fname := filepath.Base(localpath)
+	fpath := filepath.Dir(localpath)
+
+	s.GET(path, func(c Context) Response {
+		return c.File(fname, fpath)
 	})
 }
 

--- a/scope_test.go
+++ b/scope_test.go
@@ -284,8 +284,12 @@ func TestServePath(t *testing.T) {
 		if r.StatusCode != 200 {
 			t.Errorf("status code should be 200: %d", r.StatusCode)
 		}
-		if r.Filepath != "/public/test.txt" {
+		if r.Filepath != "/test.txt" {
 			t.Errorf("filepath not correct: %s", r.Filepath)
+		}
+
+		if r.Fileroot != "/public" {
+			t.Errorf("fileroot not correct: %s", r.Fileroot)
 		}
 	})
 }

--- a/scope_test.go
+++ b/scope_test.go
@@ -293,3 +293,10 @@ func TestServePath(t *testing.T) {
 		}
 	})
 }
+
+func TestFixPath(t *testing.T) {
+	p := "test"
+	if fixPath(p) != "/test" {
+		t.Errorf("path not prepended with slash: %s", fixPath(p))
+	}
+}

--- a/scope_test.go
+++ b/scope_test.go
@@ -105,7 +105,8 @@ func TestMethodRouting(t *testing.T) {
 }
 
 func TestMethodAliases(t *testing.T) {
-	{
+
+	t.Run("GET", func(t *testing.T) {
 		scope := newScope("/")
 		scope.GET("/get", func(c Context) Response {
 			return c.R("test")
@@ -116,8 +117,9 @@ func TestMethodAliases(t *testing.T) {
 		if r.StatusCode != 200 {
 			t.Error("Non 200 response code for valid method/path")
 		}
-	}
-	{
+	})
+
+	t.Run("PUT", func(t *testing.T) {
 		scope := newScope("/")
 		scope.PUT("/put", func(c Context) Response {
 			return c.R("test")
@@ -128,8 +130,8 @@ func TestMethodAliases(t *testing.T) {
 		if r.StatusCode != 200 {
 			t.Error("Non 200 response code for valid method/path")
 		}
-	}
-	{
+	})
+	t.Run("DELETE", func(t *testing.T) {
 		scope := newScope("/")
 		scope.DELETE("/delete", func(c Context) Response {
 			return c.R("test")
@@ -140,8 +142,8 @@ func TestMethodAliases(t *testing.T) {
 		if r.StatusCode != 200 {
 			t.Error("Non 200 response code for valid method/path")
 		}
-	}
-	{
+	})
+	t.Run("PATCH", func(t *testing.T) {
 		scope := newScope("/")
 		scope.PATCH("/patch", func(c Context) Response {
 			return c.R("test")
@@ -152,8 +154,8 @@ func TestMethodAliases(t *testing.T) {
 		if r.StatusCode != 200 {
 			t.Error("Non 200 response code for valid method/path")
 		}
-	}
-	{
+	})
+	t.Run("POST", func(t *testing.T) {
 		scope := newScope("/")
 		scope.POST("/post", func(c Context) Response {
 			return c.R("test")
@@ -164,7 +166,7 @@ func TestMethodAliases(t *testing.T) {
 		if r.StatusCode != 200 {
 			t.Error("Non 200 response code for valid method/path")
 		}
-	}
+	})
 }
 
 func BenchmarkScopeRoute(b *testing.B) {
@@ -258,15 +260,32 @@ func TestPanicRecovery(t *testing.T) {
 	s.GET("/foo", func(c Context) Response {
 		panic("uh oh")
 	})
-	{
-		req, err := http.NewRequest("GET", "http://example.com/foo", nil)
+	req, err := http.NewRequest("GET", "http://example.com/foo", nil)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	c := RequestContext(req)
+	r := s.Handle(c)
+	if r.StatusCode != 500 {
+		t.Errorf("status code should be 500: %d", r.StatusCode)
+	}
+}
+
+func TestServePath(t *testing.T) {
+	s := newScope("/")
+	s.ServePath("/test", "/public")
+	t.Run("valid path", func(t *testing.T) {
+		req, err := http.NewRequest("GET", "http://example.com/test/test.txt", nil)
 		if err != nil {
 			t.Fatal(err.Error())
 		}
 		c := RequestContext(req)
 		r := s.Handle(c)
-		if r.StatusCode != 500 {
-			t.Errorf("status code should be 500: %d", r.StatusCode)
+		if r.StatusCode != 200 {
+			t.Errorf("status code should be 200: %d", r.StatusCode)
 		}
-	}
+		if r.Filepath != "/public/test.txt" {
+			t.Errorf("filepath not correct: %s", r.Filepath)
+		}
+	})
 }

--- a/server.go
+++ b/server.go
@@ -107,6 +107,11 @@ func (s *Server) ServePath(path, rootpath string) {
 	s.Router.Root.ServePath(path, rootpath)
 }
 
+// ServeFile serves a static file at a given path
+func (s *Server) ServeFile(path, rootpath string) {
+	s.Router.Root.ServeFile(path, rootpath)
+}
+
 // Route - Set a route on the root scope.
 func (s *Server) Route(method, path string, h RouteHandler) {
 	s.Router.Root.Route(method, path, h)

--- a/server.go
+++ b/server.go
@@ -3,6 +3,7 @@ package celerity
 import (
 	"io"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strconv"
 )
@@ -23,38 +24,42 @@ func NewServer() *Server {
 	}
 }
 
+func (s *Server) serveFile(w http.ResponseWriter, resp *Response) {
+	fs := s.FSAdapter.RootPath(resp.Fileroot)
+	f, err := fs.Open(resp.Filepath)
+	if os.IsNotExist(err) {
+		w.WriteHeader(404)
+		w.Write([]byte("The file does not exists"))
+		return
+
+	}
+	if err != nil {
+		w.WriteHeader(500)
+		w.Write([]byte(err.Error()))
+		return
+	}
+
+	fileHeader := make([]byte, 512)
+	f.Read(fileHeader)
+	fstat, err := f.Stat()
+	if err != nil {
+
+	}
+	fsize := strconv.FormatInt(fstat.Size(), 10)
+	fname := filepath.Base(resp.Filepath)
+	contentType := http.DetectContentType(fileHeader)
+	w.Header().Set("Content-Disposition", "attachment; filename="+fname)
+	w.Header().Set("Content-Type", contentType)
+	w.Header().Set("Content-Length", fsize)
+	f.Seek(0, 0)
+	io.Copy(w, f)
+}
+
 // ServeHTTP - Serves the HTTP request. Complies with http.Handler interface
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	c := RequestContext(r)
 	c.SetQueryParamsFromURL(r.URL)
 	resp := s.Router.Handle(c, r)
-	if resp.IsFile() {
-		fs := s.FSAdapter.RootPath(resp.Fileroot)
-		f, err := fs.Open(resp.Filepath)
-		if err != nil {
-			w.WriteHeader(500)
-			return
-		}
-		fileHeader := make([]byte, 512)
-		f.Read(fileHeader)
-		fstat, _ := f.Stat()
-		fsize := strconv.FormatInt(fstat.Size(), 10)
-		fname := filepath.Base(resp.Filepath)
-		contentType := http.DetectContentType(fileHeader)
-		w.Header().Set("Content-Disposition", "attachment; filename="+fname)
-		w.Header().Set("Content-Type", contentType)
-		w.Header().Set("Content-Length", fsize)
-		f.Seek(0, 0)
-		io.Copy(w, f)
-		return
-
-	}
-
-	buf, err := s.ResponseAdapter.Process(c, resp)
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
 
 	for k, vs := range c.Response.Header {
 		for _, v := range vs {
@@ -62,8 +67,19 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	w.WriteHeader(resp.StatusCode)
-	w.Write(buf)
+	switch true {
+	case resp.IsFile():
+		s.serveFile(w, &resp)
+	default:
+		buf, err := s.ResponseAdapter.Process(c, resp)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		w.WriteHeader(resp.StatusCode)
+		w.Write(buf)
+	}
 }
 
 // Pre - Register prehandle middleware for the root scope.
@@ -84,6 +100,11 @@ func (s *Server) Start(host string) error {
 // Scope creates a new scope from the root scope
 func (s *Server) Scope(path string) *Scope {
 	return s.Router.Root.Scope(path)
+}
+
+// ServePath serves a path of static files rooted at the path given
+func (s *Server) ServePath(path, rootpath string) {
+	s.Router.Root.ServePath(path, rootpath)
 }
 
 // Route - Set a route on the root scope.

--- a/server_test.go
+++ b/server_test.go
@@ -534,15 +534,13 @@ func TestFileServing(t *testing.T) {
 	server := New()
 	adapter := NewMEMAdapter()
 	server.FSAdapter = adapter
-	server.ServePath("/test", "/public/files")
-
-	adapter.MEMFS.MkdirAll("/outsideroot", 0755)
+	server.ServeFile("/test/afile", "/public/files/test.txt")
 	afero.WriteFile(adapter.MEMFS, "/public/files/test.txt", []byte("public file"), 0755)
 
 	ts := httptest.NewServer(server)
 	defer ts.Close()
 
-	res, err := http.Get(ts.URL + "/test/test.txt")
+	res, err := http.Get(ts.URL + "/test/afile")
 	if err != nil {
 		t.Errorf("Error requesting url: %s", err.Error())
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -337,7 +337,7 @@ func TestFailResponse(t *testing.T) {
 }
 
 func TestWildcardRouting(t *testing.T) {
-	{
+	t.Run("valid path", func(t *testing.T) {
 		svr := New()
 		svr.GET("/get/*", func(c Context) Response {
 			return c.R("test")
@@ -346,11 +346,11 @@ func TestWildcardRouting(t *testing.T) {
 		c := RequestContext(req)
 		r := svr.Router.Root.Handle(c)
 		if r.StatusCode != 200 {
-			t.Errorf("Non 200 response code for valid method/path: %d", r.StatusCode)
+			t.Errorf("Non 200 response: %d", r.StatusCode)
 		}
-	}
+	})
 
-	{
+	t.Run("invalid path", func(t *testing.T) {
 		svr := New()
 		svr.GET("/get/*", func(c Context) Response {
 			return c.R("test")
@@ -359,9 +359,9 @@ func TestWildcardRouting(t *testing.T) {
 		c := RequestContext(req)
 		r := svr.Router.Root.Handle(c)
 		if r.StatusCode == 200 {
-			t.Error("200 response code for invalid method/path")
+			t.Error("200 response code")
 		}
-	}
+	})
 }
 
 func TestServerMethodAliases(t *testing.T) {


### PR DESCRIPTION
A File function was added to the context to return a file response. This is
handled in ServeHTTP if a file is set on the response the file is served
directly instead of the normal processing by the ResponseAdapter

The response was updated to have a Filepath and Fileroot field that is used
by the File response generator in the context.

Scopes now have a ServeFile function that creates a route which will serve
a local file at a given path.

Scopes now have a ServePath function that allows routes to be generated to
serve files from a local path.