### PR TITLE
Raw Responses

### DIFF
--- a/context.go
+++ b/context.go
@@ -134,6 +134,13 @@ func (c *Context) File(fileroot, filepath string) Response {
 	return c.Response
 }
 
+// Raw returns a response configured to output a raw []byte resposne. This
+// resposne will also skip the response transformation adapter.
+func (c *Context) Raw(b []byte) Response {
+	c.Response.SetRaw(b)
+	return c.Response
+}
+
 // Extract - Unmarshal request data into a structure.
 func (c *Context) Extract(obj interface{}) error {
 	decoder := json.NewDecoder(bytes.NewReader(c.Body()))

--- a/response.go
+++ b/response.go
@@ -14,6 +14,7 @@ type Response struct {
 	Header     http.Header
 	Filepath   string
 	Fileroot   string
+	raw        []byte
 }
 
 // NewResponse - Create a new response object
@@ -47,4 +48,21 @@ func (r *Response) Success() bool {
 // IsFile returns true if the response should output a local file
 func (r *Response) IsFile() bool {
 	return (r.Filepath != "")
+}
+
+// IsRaw determens if the response is a raw response
+func (r *Response) IsRaw() bool {
+	return len(r.raw) > 0
+}
+
+// SetRaw sets the responses raw output
+func (r *Response) SetRaw(b []byte) {
+	r.raw = b
+	r.Filepath = ""
+	r.Data = nil
+}
+
+// Raw returns the raw data for the request
+func (r *Response) Raw() []byte {
+	return r.raw
 }

--- a/response_test.go
+++ b/response_test.go
@@ -32,3 +32,17 @@ func TestIsFile(t *testing.T) {
 		t.Error("should return true")
 	}
 }
+
+func TestRaw(t *testing.T) {
+	r := NewResponse()
+	if r.IsRaw() {
+		t.Error("response should not be raw")
+	}
+	r.SetRaw([]byte("test"))
+	if !r.IsRaw() {
+		t.Error("response should be raw")
+	}
+	if string(r.Raw()) != "test" {
+		t.Errorf("raw data not correct: %s", string(r.Raw()))
+	}
+}

--- a/server.go
+++ b/server.go
@@ -1,6 +1,7 @@
 package celerity
 
 import (
+	"bytes"
 	"io"
 	"net/http"
 	"os"
@@ -70,6 +71,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch true {
 	case resp.IsFile():
 		s.serveFile(w, &resp)
+	case resp.IsRaw():
+		io.Copy(w, bytes.NewReader(resp.Raw()))
 	default:
 		buf, err := s.ResponseAdapter.Process(c, resp)
 		if err != nil {

--- a/server_test.go
+++ b/server_test.go
@@ -557,3 +557,30 @@ func TestFileServing(t *testing.T) {
 		t.Errorf("body was: %s", string(bbody))
 	}
 }
+
+func TestRawResponse(t *testing.T) {
+	server := New()
+	server.GET("/raw", func(c Context) Response {
+		return c.Raw([]byte("test raw"))
+	})
+
+	ts := httptest.NewServer(server)
+	defer ts.Close()
+
+	res, err := http.Get(ts.URL + "/raw")
+	if err != nil {
+		t.Errorf("Error requesting url: %s", err.Error())
+	}
+
+	if s := res.StatusCode; s != 200 {
+		t.Errorf("status code was %d", s)
+	}
+	defer res.Body.Close()
+	bbody, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		t.Errorf("Error reading response: %s", err.Error())
+	}
+	if string(bbody) != "test raw" {
+		t.Errorf("body was: %s", string(bbody))
+	}
+}


### PR DESCRIPTION
Endpoints can send byte responses to the client using a Raw function
from the context. This will skip any transformations and respond with
raw data.

This was added to allow for a catch-all response type for structures
that have not been implemented by any helper functions.