### PR TITLE
Route Types

### DIFF
--- a/fsadapter.go
+++ b/fsadapter.go
@@ -2,10 +2,13 @@ package celerity
 
 import "github.com/spf13/afero"
 
-// FSAdapter is the adapter used for gaining access to the file system
-type FSAdapter interface {
+// FileSystemAdapter is the adapter used for gaining access to the file system
+type FileSystemAdapter interface {
 	RootPath(string) afero.Fs
 }
+
+// FSAdapter is the current method of accessing the file system.
+var FSAdapter FileSystemAdapter = &OSAdapter{}
 
 // OSAdapter gives access to the file system
 type OSAdapter struct{}

--- a/route.go
+++ b/route.go
@@ -1,18 +1,78 @@
 package celerity
 
-// Route - A basic route in the server.
-type Route struct {
-	Path       RoutePath
-	Method     string
-	Handler    RouteHandler
-	Middleware []MiddlewareHandler
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Route is an interface that can be implemented by any objects wishing to
+// process url calls.
+type Route interface {
+	Match(method, path string) (bool, string)
+	Handle(Context) Response
+	RoutePath() RoutePath
+}
+
+// BasicRoute - A basic route in the server.
+type BasicRoute struct {
+	Path    RoutePath
+	Method  string
+	Handler RouteHandler
 }
 
 // RouteHandler - The handler function that gets called when a route is invoked.
 type RouteHandler func(Context) Response
 
 // Match - Matches the routes path against the incomming url
-func (r *Route) Match(method, path string) (bool, string) {
+func (r *BasicRoute) Match(method, path string) (bool, string) {
 	ok, xtra := r.Path.Match(path)
 	return (ok && method == r.Method && xtra == ""), xtra
+}
+
+// Handle processes the request by passing it to the RouteHandler function
+func (r *BasicRoute) Handle(c Context) Response {
+	return r.Handler(c)
+}
+
+// RoutePath returns the RoutePath for the route.
+func (r *BasicRoute) RoutePath() RoutePath {
+	return r.Path
+}
+
+func (r *BasicRoute) String() string {
+	return fmt.Sprint(r.Method, "\t", r.Path)
+}
+
+// LocalFileRoute will handle serving a single file from the local file system
+// to a given path.
+type LocalFileRoute struct {
+	Path      RoutePath
+	LocalPath string
+}
+
+// Match checks if the incoming path matches the route path and if the local
+// file exists.
+func (l *LocalFileRoute) Match(method string, path string) (bool, string) {
+	ok, xtra := l.Path.Match(path)
+	fs := FSAdapter.RootPath(filepath.Dir(l.LocalPath))
+	if !ok || method != GET || xtra != "" {
+		return false, path
+	}
+	if _, err := fs.Stat(l.LocalPath); os.IsNotExist(err) {
+		return false, path
+	}
+	return true, xtra
+}
+
+// Handle sets the response to return a local file.
+func (l *LocalFileRoute) Handle(c Context) Response {
+	fname := "/" + filepath.Base(l.LocalPath)
+	fpath := filepath.Dir(l.LocalPath)
+	return c.File(fpath, fname)
+}
+
+// RoutePath returns the route path for the route.
+func (l *LocalFileRoute) RoutePath() RoutePath {
+	panic("not implemented")
 }

--- a/route.go
+++ b/route.go
@@ -86,7 +86,7 @@ type LocalPathRoute struct {
 	LocalPath string
 }
 
-//Match checks if a file exists under the local path
+// Match checks if a file exists under the local path
 func (l *LocalPathRoute) Match(method string, path string) (bool, string) {
 	fs := FSAdapter.RootPath(l.LocalPath)
 	fname := "/" + path[len(l.Path):]
@@ -96,14 +96,14 @@ func (l *LocalPathRoute) Match(method string, path string) (bool, string) {
 	return true, ""
 }
 
-//Handle sets the resposne up to serve the local file.
+// Handle sets the resposne up to serve the local file.
 func (l *LocalPathRoute) Handle(c Context) Response {
 	fname := c.ScopedPath[len(l.Path):]
 	fpath := l.LocalPath
 	return c.File(fpath, fname)
 }
 
-//RoutePath returns the routepath for the route
+// RoutePath returns the routepath for the route
 func (l *LocalPathRoute) RoutePath() RoutePath {
 	return l.Path
 }

--- a/route_test.go
+++ b/route_test.go
@@ -2,9 +2,9 @@ package celerity
 
 import "testing"
 
-func TestRouteMatch(t *testing.T) {
+func TestBasicRouteMatch(t *testing.T) {
 	{
-		r := Route{
+		r := &BasicRoute{
 			Method: GET,
 			Path:   "/users",
 		}
@@ -16,7 +16,7 @@ func TestRouteMatch(t *testing.T) {
 		}
 	}
 	{
-		r := Route{
+		r := &BasicRoute{
 			Method: POST,
 			Path:   "/users",
 		}

--- a/route_test.go
+++ b/route_test.go
@@ -1,6 +1,10 @@
 package celerity
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+)
 
 func TestBasicRouteMatch(t *testing.T) {
 	{
@@ -24,4 +28,45 @@ func TestBasicRouteMatch(t *testing.T) {
 			t.Error("should not match incorrect method")
 		}
 	}
+}
+
+func TestLocalFileRoute(t *testing.T) {
+	adapter := NewMEMAdapter()
+	FSAdapter = adapter
+	r := &LocalFileRoute{
+		Path:      "/public/test.txt",
+		LocalPath: "/files/test.txt",
+	}
+
+	t.Run("without file", func(t *testing.T) {
+		if ok, _ := r.Match(GET, "/public/test.txt"); ok {
+			t.Error("should not match non existant file")
+		}
+	})
+	t.Run("with file", func(t *testing.T) {
+		afero.WriteFile(adapter.MEMFS, "/files/test.txt", []byte("public file"), 0755)
+		if ok, _ := r.Match(GET, "/public/test.txt"); !ok {
+			t.Error("should match existing file")
+		}
+	})
+}
+
+func TestLocalPathRoute(t *testing.T) {
+	adapter := NewMEMAdapter()
+	FSAdapter = adapter
+	r := &LocalPathRoute{
+		Path:      "/public/",
+		LocalPath: "/files/",
+	}
+	t.Run("without file", func(t *testing.T) {
+		if ok, _ := r.Match(GET, "/public/test.txt"); ok {
+			t.Error("should not match non existant file")
+		}
+	})
+	t.Run("with file", func(t *testing.T) {
+		afero.WriteFile(adapter.MEMFS, "/files/test.txt", []byte("public file"), 0755)
+		if ok, _ := r.Match(GET, "/public/test.txt"); !ok {
+			t.Error("should match existing file")
+		}
+	})
 }

--- a/scope.go
+++ b/scope.go
@@ -71,10 +71,11 @@ func (s *Scope) Route(method, path string, handler RouteHandler) Route {
 
 // ServePath serves static files at a filepath
 func (s *Scope) ServePath(path, staticpath string) {
-	s.GET(path+"/*", func(c Context) Response {
-		path := fmt.Sprintf("/%s", strings.TrimLeft(c.ScopedPath[len(path):], "/"))
-		return c.File(staticpath, path)
-	})
+	r := &LocalPathRoute{
+		Path:      RoutePath(path),
+		LocalPath: staticpath,
+	}
+	s.Routes = append(s.Routes, r)
 }
 
 // ServeFile serves static files at a filepath

--- a/scope.go
+++ b/scope.go
@@ -3,7 +3,6 @@ package celerity
 import (
 	"fmt"
 	"net/http"
-	"path/filepath"
 	"runtime/debug"
 	"strings"
 )
@@ -61,7 +60,7 @@ func (s *Scope) DELETE(path string, handler RouteHandler) Route {
 
 // Route - Create a new route within the scope
 func (s *Scope) Route(method, path string, handler RouteHandler) Route {
-	r := Route{
+	r := &BasicRoute{
 		Path:    RoutePath(path),
 		Method:  method,
 		Handler: handler,
@@ -80,12 +79,11 @@ func (s *Scope) ServePath(path, staticpath string) {
 
 // ServeFile serves static files at a filepath
 func (s *Scope) ServeFile(path, localpath string) {
-	fname := "/" + filepath.Base(localpath)
-	fpath := filepath.Dir(localpath)
-
-	s.GET(path, func(c Context) Response {
-		return c.File(fpath, fname)
-	})
+	r := &LocalFileRoute{
+		Path:      RoutePath(path),
+		LocalPath: localpath,
+	}
+	s.Routes = append(s.Routes, r)
 }
 
 // Use - Use a middleware function
@@ -141,9 +139,9 @@ func (s *Scope) handleWithMiddleware(c Context, middleware []MiddlewareHandler) 
 
 		for _, r := range s.Routes {
 			if ok, _ := r.Match(c.Request.Method, c.ScopedPath); ok {
-				c.SetParams(r.Path.GetURLParams(c.Request.URL.Path))
+				c.SetParams(r.RoutePath().GetURLParams(c.Request.URL.Path))
 				var h RouteHandler
-				h = r.Handler
+				h = r.Handle
 				for i := len(s.Middleware); i > 0; i-- {
 					h = s.Middleware[i-1](h)
 				}

--- a/scope_test.go
+++ b/scope_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+
+	"github.com/spf13/afero"
 )
 
 func emptyHandler(c Context) Response {
@@ -273,6 +275,9 @@ func TestPanicRecovery(t *testing.T) {
 
 func TestServePath(t *testing.T) {
 	s := newScope("/")
+	adapter := NewMEMAdapter()
+	FSAdapter = adapter
+	afero.WriteFile(adapter.MEMFS, "/public/test.txt", []byte("public file"), 0755)
 	s.ServePath("/test", "/public")
 	t.Run("valid path", func(t *testing.T) {
 		req, err := http.NewRequest("GET", "http://example.com/test/test.txt", nil)

--- a/server.go
+++ b/server.go
@@ -12,7 +12,6 @@ import (
 // Server - Main server instance
 type Server struct {
 	Router          *Router
-	FSAdapter       FSAdapter
 	ResponseAdapter ResponseAdapter
 }
 
@@ -21,12 +20,11 @@ func NewServer() *Server {
 	return &Server{
 		ResponseAdapter: &JSONResponseAdapter{},
 		Router:          NewRouter(),
-		FSAdapter:       &OSAdapter{},
 	}
 }
 
 func (s *Server) serveFile(w http.ResponseWriter, resp *Response) {
-	fs := s.FSAdapter.RootPath(resp.Fileroot)
+	fs := FSAdapter.RootPath(resp.Fileroot)
 	f, err := fs.Open(resp.Filepath)
 	if os.IsNotExist(err) {
 		w.WriteHeader(404)

--- a/server_test.go
+++ b/server_test.go
@@ -534,6 +534,7 @@ func TestFileServing(t *testing.T) {
 	server := New()
 	adapter := NewMEMAdapter()
 	FSAdapter = adapter
+	viper.Set("ENV", DEV)
 	server.ServeFile("/test/afile", "/public/files/test.txt")
 	server.ServePath("/files", "/public/files")
 	server.GET("/files/normal-route", func(c Context) Response {
@@ -591,10 +592,14 @@ func TestFileServing(t *testing.T) {
 		}
 		defer res.Body.Close()
 		bbody, err := ioutil.ReadAll(res.Body)
+		var data = map[string]interface{}{}
+
+		json.Unmarshal(bbody, &data)
+
 		if err != nil {
 			t.Errorf("Error reading response: %s", err.Error())
 		}
-		if string(bbody) != "test" {
+		if data["data"].(string) != "test" {
 			t.Errorf("body was: %s", string(bbody))
 		}
 	})

--- a/servercli.go
+++ b/servercli.go
@@ -141,6 +141,6 @@ func printScope(s *Scope) {
 	}
 
 	for _, r := range s.Routes {
-		vox.Println("\t", r.Method, "\t", r.Path)
+		vox.Println("\t", r)
 	}
 }


### PR DESCRIPTION
Routes have been moved into an interface and routes can now be any structure that implements it. This was done to better support different types of routing. BasicRoute holds all previous functionality, but two other route structures were added LocalFileRoute and LocalPathRoute to better handle file serving. This lets those routes implement their own matching logic to allow passing through when the local file doesn't exist.

This also allows scope collision to work correctly with served paths.

Resolves #48 