### PR TITLE
Universal Logging

### DIFF
--- a/context.go
+++ b/context.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/5Sigma/vox"
 	"github.com/tidwall/gjson"
 
 	"github.com/google/uuid"
@@ -24,6 +25,7 @@ type Context struct {
 	URLParams   Params
 	QueryParams Params
 	properties  map[string]interface{}
+	Log         *vox.Vox
 	Response    Response
 	Env         string
 	ScopedPath  string
@@ -32,6 +34,7 @@ type Context struct {
 
 // NewContext Create a new context object
 func NewContext() Context {
+
 	return Context{
 		URLParams:   Params(map[string]string{}),
 		QueryParams: Params(map[string]string{}),

--- a/fsadapter.go
+++ b/fsadapter.go
@@ -2,10 +2,13 @@ package celerity
 
 import "github.com/spf13/afero"
 
-// FSAdapter is the adapter used for gaining access to the file system
-type FSAdapter interface {
+// FileSystemAdapter is the adapter used for gaining access to the file system
+type FileSystemAdapter interface {
 	RootPath(string) afero.Fs
 }
+
+// FSAdapter is the current method of accessing the file system.
+var FSAdapter FileSystemAdapter = &OSAdapter{}
 
 // OSAdapter gives access to the file system
 type OSAdapter struct{}

--- a/middleware/request_logger.go
+++ b/middleware/request_logger.go
@@ -1,48 +1,42 @@
 package middleware
 
 import (
-	"io"
 	"net/url"
-	"os"
 	"strings"
 	"text/template"
 	"time"
 
 	"github.com/5Sigma/celerity"
+	"github.com/5Sigma/vox"
 )
 
 // RequestLoggerConfig configures the request logger middleware and can be
 // passed to RequestLoggerWithConfig.
 type RequestLoggerConfig struct {
-	ConsoleOut      io.Writer
 	ConsoleTemplate string
+	Log             *vox.Vox
 }
 
 // RequestLoggerData is used to format the output for console and file logging
 // operations.
 type RequestLoggerData struct {
-	Now         time.Time
-	URL         *url.URL
-	RequestTime time.Duration
-	Context     *celerity.Context
-	Response    *celerity.Response
+	Now      time.Time
+	URL      *url.URL
+	Duration time.Duration
+	C        *celerity.Context
+	R        *celerity.Response
 }
 
 // NewLoggerConfig creates a default configuration for RequestLoggerConfig.
 func NewLoggerConfig() RequestLoggerConfig {
 	return RequestLoggerConfig{
-		ConsoleOut: os.Stdout,
 		ConsoleTemplate: `
-		{{ .Context.RequestID }} - [{{.Now.Format "1/2/2006 15:04:05"}}] - {{ .Context.Request.Method }} {{.URL.Path}} ({{ .RequestTime }}) - {{ .Response.StatusCode }}  {{ .Response.StatusText }}
-{{ if eq .Response.Success false -}}
-	ERROR: {{ .Response.Error }}
+{{ .C.RequestID }} - [{{.Now.Format "1/2/2006 15:04:05"}}] - {{ .C.Request.Method }} {{.URL.Path}} ({{ .Duration }}) - {{ .R.StatusCode }}  {{ .R.StatusText }}
+{{ if eq .R.Success false -}}
+	ERROR: {{ .R.Error }}
 {{- end }}
 `,
 	}
-}
-
-// ConsoleOutput generates the console line output for the request
-func (rlc *RequestLoggerConfig) ConsoleOutput(ctx celerity.Context, r celerity.Response) {
 }
 
 // RequestLogger creates a new logger middleware with sane defaults.
@@ -52,26 +46,30 @@ func RequestLogger() celerity.MiddlewareHandler {
 
 // RequestLoggerWithConfig creates a new Request logger with the given config.
 func RequestLoggerWithConfig(rlc RequestLoggerConfig) celerity.MiddlewareHandler {
+	if rlc.Log == nil {
+		rlc.Log = vox.New()
+	}
+	tmpl, err := template.New("console").Parse(strings.TrimSpace(rlc.ConsoleTemplate) + "\n")
+	if err != nil {
+		return func(next celerity.RouteHandler) celerity.RouteHandler {
+			return func(c celerity.Context) celerity.Response {
+				return next(c)
+			}
+		}
+	}
 	return func(next celerity.RouteHandler) celerity.RouteHandler {
 		return func(c celerity.Context) celerity.Response {
 			start := time.Now()
 			r := next(c)
 			reqTime := time.Since(start)
-
 			data := &RequestLoggerData{
-				URL:         c.Request.URL,
-				Now:         time.Now(),
-				RequestTime: reqTime,
-				Context:     &c,
-				Response:    &r,
+				URL:      c.Request.URL,
+				Now:      time.Now(),
+				Duration: reqTime,
+				C:        &c,
+				R:        &r,
 			}
-
-			t, err := template.New("console").Parse(strings.TrimSpace(rlc.ConsoleTemplate) + "\n")
-			if err != nil {
-				return r
-			}
-			t.Execute(c.Log, data)
-
+			tmpl.Execute(rlc.Log, data)
 			return r
 		}
 	}

--- a/middleware/request_logger.go
+++ b/middleware/request_logger.go
@@ -70,7 +70,7 @@ func RequestLoggerWithConfig(rlc RequestLoggerConfig) celerity.MiddlewareHandler
 			if err != nil {
 				return r
 			}
-			t.Execute(rlc.ConsoleOut, data)
+			t.Execute(c.Log, data)
 
 			return r
 		}

--- a/middleware/request_logger_test.go
+++ b/middleware/request_logger_test.go
@@ -14,9 +14,9 @@ func TestConsoleOutput(t *testing.T) {
 		return c.R(nil)
 	})
 
-	out := new(bytes.Buffer)
 	config := NewLoggerConfig()
-	config.ConsoleOut = out
+	out := new(bytes.Buffer)
+	svr.Log.SetOutput(out)
 
 	svr.Use(RequestLoggerWithConfig(config))
 

--- a/middleware/request_logger_test.go
+++ b/middleware/request_logger_test.go
@@ -1,11 +1,11 @@
 package middleware
 
 import (
-	"bytes"
 	"testing"
 
 	"github.com/5Sigma/celerity"
 	"github.com/5Sigma/celerity/celeritytest"
+	"github.com/5Sigma/vox"
 )
 
 func TestConsoleOutput(t *testing.T) {
@@ -15,14 +15,16 @@ func TestConsoleOutput(t *testing.T) {
 	})
 
 	config := NewLoggerConfig()
-	out := new(bytes.Buffer)
-	svr.Log.SetOutput(out)
+	v := vox.New()
+	pipeline := v.Test()
+	config.Log = v
 
 	svr.Use(RequestLoggerWithConfig(config))
 
 	celeritytest.Get(svr, "/foo")
 
-	if out.Len() < 54 {
-		t.Errorf("output length was not correct: %d, should be > 54", out.Len())
+	if len(pipeline.All()) < 54 {
+		t.Errorf("output length was not correct: %d, should be > 54\n%s",
+			len(pipeline.Last()), pipeline.Last())
 	}
 }

--- a/route.go
+++ b/route.go
@@ -1,18 +1,109 @@
 package celerity
 
-// Route - A basic route in the server.
-type Route struct {
-	Path       RoutePath
-	Method     string
-	Handler    RouteHandler
-	Middleware []MiddlewareHandler
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Route is an interface that can be implemented by any objects wishing to
+// process url calls.
+type Route interface {
+	Match(method, path string) (bool, string)
+	Handle(Context) Response
+	RoutePath() RoutePath
+}
+
+// BasicRoute - A basic route in the server.
+type BasicRoute struct {
+	Path    RoutePath
+	Method  string
+	Handler RouteHandler
 }
 
 // RouteHandler - The handler function that gets called when a route is invoked.
 type RouteHandler func(Context) Response
 
 // Match - Matches the routes path against the incomming url
-func (r *Route) Match(method, path string) (bool, string) {
+func (r *BasicRoute) Match(method, path string) (bool, string) {
 	ok, xtra := r.Path.Match(path)
 	return (ok && method == r.Method && xtra == ""), xtra
+}
+
+// Handle processes the request by passing it to the RouteHandler function
+func (r *BasicRoute) Handle(c Context) Response {
+	return r.Handler(c)
+}
+
+// RoutePath returns the RoutePath for the route.
+func (r *BasicRoute) RoutePath() RoutePath {
+	return r.Path
+}
+
+func (r *BasicRoute) String() string {
+	return fmt.Sprint(r.Method, "\t", r.Path)
+}
+
+// LocalFileRoute will handle serving a single file from the local file system
+// to a given path.
+type LocalFileRoute struct {
+	Path      RoutePath
+	LocalPath string
+}
+
+// Match checks if the incoming path matches the route path and if the local
+// file exists.
+func (l *LocalFileRoute) Match(method string, path string) (bool, string) {
+	ok, xtra := l.Path.Match(path)
+	fs := FSAdapter.RootPath(filepath.Dir(l.LocalPath))
+	if !ok || method != GET || xtra != "" {
+		return false, path
+	}
+	fname := "/" + filepath.Base(l.LocalPath)
+	if _, err := fs.Stat(fname); os.IsNotExist(err) {
+		return false, path
+	}
+	return true, xtra
+}
+
+// Handle sets the response to return a local file.
+func (l *LocalFileRoute) Handle(c Context) Response {
+	fname := "/" + filepath.Base(l.LocalPath)
+	fpath := filepath.Dir(l.LocalPath)
+	return c.File(fpath, fname)
+}
+
+// RoutePath returns the route path for the route.
+func (l *LocalFileRoute) RoutePath() RoutePath {
+	return l.Path
+}
+
+// LocalPathRoute handles serving any file under a path. If the requested file
+// exists it will be served if not the router will continue processing
+// routes.
+type LocalPathRoute struct {
+	Path      RoutePath
+	LocalPath string
+}
+
+// Match checks if a file exists under the local path
+func (l *LocalPathRoute) Match(method string, path string) (bool, string) {
+	fs := FSAdapter.RootPath(l.LocalPath)
+	fname := "/" + path[len(l.Path):]
+	if _, err := fs.Stat(fname); os.IsNotExist(err) {
+		return false, path
+	}
+	return true, ""
+}
+
+// Handle sets the resposne up to serve the local file.
+func (l *LocalPathRoute) Handle(c Context) Response {
+	fname := c.ScopedPath[len(l.Path):]
+	fpath := l.LocalPath
+	return c.File(fpath, fname)
+}
+
+// RoutePath returns the routepath for the route
+func (l *LocalPathRoute) RoutePath() RoutePath {
+	return l.Path
 }

--- a/route_test.go
+++ b/route_test.go
@@ -1,10 +1,14 @@
 package celerity
 
-import "testing"
+import (
+	"testing"
 
-func TestRouteMatch(t *testing.T) {
+	"github.com/spf13/afero"
+)
+
+func TestBasicRouteMatch(t *testing.T) {
 	{
-		r := Route{
+		r := &BasicRoute{
 			Method: GET,
 			Path:   "/users",
 		}
@@ -16,7 +20,7 @@ func TestRouteMatch(t *testing.T) {
 		}
 	}
 	{
-		r := Route{
+		r := &BasicRoute{
 			Method: POST,
 			Path:   "/users",
 		}
@@ -24,4 +28,45 @@ func TestRouteMatch(t *testing.T) {
 			t.Error("should not match incorrect method")
 		}
 	}
+}
+
+func TestLocalFileRoute(t *testing.T) {
+	adapter := NewMEMAdapter()
+	FSAdapter = adapter
+	r := &LocalFileRoute{
+		Path:      "/public/test.txt",
+		LocalPath: "/files/test.txt",
+	}
+
+	t.Run("without file", func(t *testing.T) {
+		if ok, _ := r.Match(GET, "/public/test.txt"); ok {
+			t.Error("should not match non existant file")
+		}
+	})
+	t.Run("with file", func(t *testing.T) {
+		afero.WriteFile(adapter.MEMFS, "/files/test.txt", []byte("public file"), 0755)
+		if ok, _ := r.Match(GET, "/public/test.txt"); !ok {
+			t.Error("should match existing file")
+		}
+	})
+}
+
+func TestLocalPathRoute(t *testing.T) {
+	adapter := NewMEMAdapter()
+	FSAdapter = adapter
+	r := &LocalPathRoute{
+		Path:      "/public/",
+		LocalPath: "/files/",
+	}
+	t.Run("without file", func(t *testing.T) {
+		if ok, _ := r.Match(GET, "/public/test.txt"); ok {
+			t.Error("should not match non existant file")
+		}
+	})
+	t.Run("with file", func(t *testing.T) {
+		afero.WriteFile(adapter.MEMFS, "/files/test.txt", []byte("public file"), 0755)
+		if ok, _ := r.Match(GET, "/public/test.txt"); !ok {
+			t.Error("should match existing file")
+		}
+	})
 }

--- a/scope_test.go
+++ b/scope_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+
+	"github.com/spf13/afero"
 )
 
 func emptyHandler(c Context) Response {
@@ -273,6 +275,9 @@ func TestPanicRecovery(t *testing.T) {
 
 func TestServePath(t *testing.T) {
 	s := newScope("/")
+	adapter := NewMEMAdapter()
+	FSAdapter = adapter
+	afero.WriteFile(adapter.MEMFS, "/public/test.txt", []byte("public file"), 0755)
 	s.ServePath("/test", "/public")
 	t.Run("valid path", func(t *testing.T) {
 		req, err := http.NewRequest("GET", "http://example.com/test/test.txt", nil)

--- a/server.go
+++ b/server.go
@@ -23,7 +23,6 @@ func NewServer() *Server {
 	return &Server{
 		ResponseAdapter: &JSONResponseAdapter{},
 		Router:          NewRouter(),
-		FSAdapter:       &OSAdapter{},
 		Log:             vox.New(),
 	}
 }

--- a/server.go
+++ b/server.go
@@ -12,7 +12,6 @@ import (
 // Server - Main server instance
 type Server struct {
 	Router          *Router
-	FSAdapter       FSAdapter
 	ResponseAdapter ResponseAdapter
 }
 
@@ -21,12 +20,11 @@ func NewServer() *Server {
 	return &Server{
 		ResponseAdapter: &JSONResponseAdapter{},
 		Router:          NewRouter(),
-		FSAdapter:       &OSAdapter{},
 	}
 }
 
 func (s *Server) serveFile(w http.ResponseWriter, resp *Response) {
-	fs := s.FSAdapter.RootPath(resp.Fileroot)
+	fs := FSAdapter.RootPath(resp.Fileroot)
 	f, err := fs.Open(resp.Filepath)
 	if os.IsNotExist(err) {
 		w.WriteHeader(404)

--- a/server.go
+++ b/server.go
@@ -7,12 +7,15 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+
+	"github.com/5Sigma/vox"
 )
 
 // Server - Main server instance
 type Server struct {
 	Router          *Router
 	ResponseAdapter ResponseAdapter
+	Log             *vox.Vox
 }
 
 // NewServer - Initialize a new server
@@ -20,6 +23,8 @@ func NewServer() *Server {
 	return &Server{
 		ResponseAdapter: &JSONResponseAdapter{},
 		Router:          NewRouter(),
+		FSAdapter:       &OSAdapter{},
+		Log:             vox.New(),
 	}
 }
 
@@ -57,6 +62,7 @@ func (s *Server) serveFile(w http.ResponseWriter, resp *Response) {
 // ServeHTTP - Serves the HTTP request. Complies with http.Handler interface
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	c := RequestContext(r)
+	c.Log = s.Log
 	c.SetQueryParamsFromURL(r.URL)
 	resp := s.Router.Handle(c, r)
 

--- a/server_test.go
+++ b/server_test.go
@@ -467,7 +467,7 @@ func BenchmarkMiddleware(b *testing.B) {
 func TestStaticPathServing(t *testing.T) {
 	server := New()
 	adapter := NewMEMAdapter()
-	server.FSAdapter = adapter
+	FSAdapter = adapter
 	server.ServePath("/test", "/public/files")
 
 	adapter.MEMFS.MkdirAll("/outsideroot", 0755)
@@ -533,29 +533,76 @@ func TestStaticPathServing(t *testing.T) {
 func TestFileServing(t *testing.T) {
 	server := New()
 	adapter := NewMEMAdapter()
-	server.FSAdapter = adapter
+	FSAdapter = adapter
+	viper.Set("ENV", DEV)
 	server.ServeFile("/test/afile", "/public/files/test.txt")
+	server.ServePath("/files", "/public/files")
+	server.GET("/files/normal-route", func(c Context) Response {
+		return c.R("test")
+	})
 	afero.WriteFile(adapter.MEMFS, "/public/files/test.txt", []byte("public file"), 0755)
 
 	ts := httptest.NewServer(server)
 	defer ts.Close()
 
-	res, err := http.Get(ts.URL + "/test/afile")
-	if err != nil {
-		t.Errorf("Error requesting url: %s", err.Error())
-	}
+	t.Run("requesting single file", func(t *testing.T) {
+		res, err := http.Get(ts.URL + "/test/afile")
+		if err != nil {
+			t.Errorf("Error requesting url: %s", err.Error())
+		}
 
-	if s := res.StatusCode; s != 200 {
-		t.Errorf("status code was %d", s)
-	}
-	defer res.Body.Close()
-	bbody, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		t.Errorf("Error reading response: %s", err.Error())
-	}
-	if string(bbody) != "public file" {
-		t.Errorf("body was: %s", string(bbody))
-	}
+		if s := res.StatusCode; s != 200 {
+			t.Errorf("status code was %d", s)
+		}
+		defer res.Body.Close()
+		bbody, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			t.Errorf("Error reading response: %s", err.Error())
+		}
+		if string(bbody) != "public file" {
+			t.Errorf("body was: %s", string(bbody))
+		}
+	})
+	t.Run("requesting file from path", func(t *testing.T) {
+		res, err := http.Get(ts.URL + "/files/test.txt")
+		if err != nil {
+			t.Errorf("Error requesting url: %s", err.Error())
+		}
+
+		if s := res.StatusCode; s != 200 {
+			t.Errorf("status code was %d", s)
+		}
+		defer res.Body.Close()
+		bbody, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			t.Errorf("Error reading response: %s", err.Error())
+		}
+		if string(bbody) != "public file" {
+			t.Errorf("body was: %s", string(bbody))
+		}
+	})
+	t.Run("requesting colliding route", func(t *testing.T) {
+		res, err := http.Get(ts.URL + "/files/normal-route")
+		if err != nil {
+			t.Errorf("Error requesting url: %s", err.Error())
+		}
+
+		if s := res.StatusCode; s != 200 {
+			t.Errorf("status code was %d", s)
+		}
+		defer res.Body.Close()
+		bbody, err := ioutil.ReadAll(res.Body)
+		var data = map[string]interface{}{}
+
+		json.Unmarshal(bbody, &data)
+
+		if err != nil {
+			t.Errorf("Error reading response: %s", err.Error())
+		}
+		if data["data"].(string) != "test" {
+			t.Errorf("body was: %s", string(bbody))
+		}
+	})
 }
 
 func TestRawResponse(t *testing.T) {

--- a/servercli.go
+++ b/servercli.go
@@ -141,6 +141,6 @@ func printScope(s *Scope) {
 	}
 
 	for _, r := range s.Routes {
-		vox.Println("\t", r.Method, "\t", r.Path)
+		vox.Println("\t", r)
 	}
 }

--- a/servercli.go
+++ b/servercli.go
@@ -46,7 +46,8 @@ to quickly create a Cobra application.`,
 			)
 			vox.Println(banner)
 			server := onRun()
-			vox.Println("Listening on ", hostString)
+			vox.PrintProperty("Bound IP", viper.GetString("host"))
+			vox.PrintProperty("Port", viper.GetString("port"))
 			server.Start(hostString)
 		},
 	}


### PR DESCRIPTION
Added a log instance to the server which is passed to the Context. This gives endpoints the access to a unified rolling application log.

Refactored the way the request logger middleware works. It now uses an internal Vox instance to output logs which is provided inside the configuration structure.

This should allow more control of the output stream now that it can take advantage of vox output pipelines.

Resolves #45 