### PR TITLE
Add Ability to Set Status Code on Response

### DIFF
--- a/context.go
+++ b/context.go
@@ -161,6 +161,7 @@ func (c *Context) Raw(b []byte) Response {
 	return c.Response
 }
 
+// SetDefaults sets default values for the response, in the current case this is just a default status code.
 func (c *Context) SetDefaults() {
 	// If the user has specified their own status code we don't want to override it.
 	if c.Response.StatusCode == -1 {

--- a/context.go
+++ b/context.go
@@ -79,9 +79,7 @@ func (c *Context) R(obj interface{}) Response {
 
 // Respond Respond with an object
 func (c *Context) Respond(obj interface{}) Response {
-	c.Response.StatusCode = 200
-	c.Response.Data = obj
-	return c.Response
+	return c.Status(-1, obj)
 }
 
 // F is an alias for the Fail function
@@ -102,11 +100,28 @@ func (c *Context) Body() []byte {
 	return c.data
 }
 
+// S is an alias for the Status function
+func (c *Context) S(status int, obj interface{}) Response {
+	return c.Status(status, obj)
+}
+
+// Status is used to set a status code for a response regardless of if it
+// is for a successful or unsuccessful response
+func (c *Context) Status(status int, obj interface{}) Response {
+	c.Response.StatusCode = status
+	c.SetDefaults()
+	c.Response.Data = obj
+	return c.Response
+}
+
 // Fail is used for unrecoverable and internal errors. In a production
 // environment the error is not passed to the client.
 // message.
 func (c *Context) Fail(err error) Response {
-	c.Response.StatusCode = 500
+	// If the user has specified their own status code we don't want to override it.
+	if c.Response.StatusCode == -1 {
+		c.Response.StatusCode = 500
+	}
 	c.Response.Data = nil
 	if viper.GetString("env") == PROD {
 		c.Response.Error = errors.New("the request could not be processed")
@@ -122,7 +137,7 @@ func (c *Context) E(status int, err error) Response {
 	return c.Error(status, err)
 }
 
-// Error - Returns a erorr and outputs the passed error message.
+// Error - Returns a error and outputs the passed error message.
 func (c *Context) Error(status int, err error) Response {
 	c.Response.StatusCode = status
 	c.Response.Data = nil
@@ -132,6 +147,7 @@ func (c *Context) Error(status int, err error) Response {
 
 // File sets the response to output a file from a local filepath
 func (c *Context) File(fileroot, filepath string) Response {
+	c.SetDefaults()
 	c.Response.Filepath = filepath
 	c.Response.Fileroot = fileroot
 	return c.Response
@@ -140,8 +156,16 @@ func (c *Context) File(fileroot, filepath string) Response {
 // Raw returns a response configured to output a raw []byte resposne. This
 // resposne will also skip the response transformation adapter.
 func (c *Context) Raw(b []byte) Response {
+	c.SetDefaults()
 	c.Response.SetRaw(b)
 	return c.Response
+}
+
+func (c *Context) SetDefaults() {
+	// If the user has specified their own status code we don't want to override it.
+	if c.Response.StatusCode == -1 {
+		c.Response.StatusCode = 200
+	}
 }
 
 // Extract - Unmarshal request data into a structure.

--- a/context_test.go
+++ b/context_test.go
@@ -41,6 +41,25 @@ func TestRespond(t *testing.T) {
 	}
 }
 
+func TestStatus(t *testing.T) {
+	c := NewContext()
+	data := map[string]string{"name": "jim"}
+	r := c.Status(201, data)
+	if r.StatusCode != 201 {
+		t.Errorf("Status code not set to 201 (%d)", r.StatusCode)
+	}
+	if r.Error != nil {
+		t.Errorf("Error not empty: %s", r.Error.Error())
+	}
+	if v, ok := r.Data.(map[string]string); ok {
+		if v["name"] != "jim" {
+			t.Errorf("name not set correctly in data: %s", v["name"])
+		}
+	} else {
+		t.Error("response data not properly set")
+	}
+}
+
 func TestFail(t *testing.T) {
 	c := NewContext()
 	r := c.Fail(errors.New("some error"))

--- a/response.go
+++ b/response.go
@@ -22,7 +22,7 @@ func NewResponse() Response {
 	return Response{
 		Meta:       map[string]interface{}{},
 		Header:     http.Header{},
-		StatusCode: 200,
+		StatusCode: -1,
 	}
 }
 


### PR DESCRIPTION
Set the default StatusCode to `-1`.
Added a new method on `Context` called `Status` which allows a user to set the status code for their response when responding as `application/json`.
Added relevant test for the new functionality.

Closes #28