### PR TITLE
Add some tests for other server methods that weren't previously covered.

### DIFF
--- a/celeritytest/celeritytest.go
+++ b/celeritytest/celeritytest.go
@@ -17,6 +17,27 @@ func Post(s *celerity.Server, path string, data []byte) (*Response, error) {
 	return svr.Post(path, data)
 }
 
+//Put creates a TestServer for the given celerity.Server and makes a PUT
+//request against it using the TestServer.Put function.
+func Put(s *celerity.Server, path string, data []byte) (*Response, error) {
+	svr := &TestServer{s}
+	return svr.Put(path, data)
+}
+
+//Patch creates a TestServer for the given celerity.Server and makes a Patch
+//request against it using the TestServer.Patch function.
+func Patch(s *celerity.Server, path string, data []byte) (*Response, error) {
+	svr := &TestServer{s}
+	return svr.Patch(path, data)
+}
+
+//Delete creates a TestServer for the given celerity.Server and makes a Delete
+//request against it using the TestServer.Delete function.
+func Delete(s *celerity.Server, path string, data []byte) (*Response, error) {
+	svr := &TestServer{s}
+	return svr.Delete(path, data)
+}
+
 //Get creates a TestServer for the given celerity.Server and makes a GET
 //request against it using the TestServer.Get function.
 func Get(s *celerity.Server, path string) (*Response, error) {
@@ -54,6 +75,42 @@ type RequestOptions struct {
 func (ts *TestServer) Post(path string, data []byte) (*Response, error) {
 	reqOpts := RequestOptions{
 		Method: celerity.POST,
+		Path:   path,
+		Data:   data,
+	}
+	return ts.Request(reqOpts)
+}
+
+// Put makes a PUT request against the test server. This function is called
+// by the package level Put function in cases where you want to make a one off
+// request.
+func (ts *TestServer) Put(path string, data []byte) (*Response, error) {
+	reqOpts := RequestOptions{
+		Method: celerity.PUT,
+		Path:   path,
+		Data:   data,
+	}
+	return ts.Request(reqOpts)
+}
+
+// Patch makes a PATCH request against the test server. This function is called
+// by the package level Patch function in cases where you want to make a one off
+// request.
+func (ts *TestServer) Patch(path string, data []byte) (*Response, error) {
+	reqOpts := RequestOptions{
+		Method: celerity.PATCH,
+		Path:   path,
+		Data:   data,
+	}
+	return ts.Request(reqOpts)
+}
+
+// Delete makes a DELETE request against the test server. This function is called
+// by the package level Delete function in cases where you want to make a one off
+// request.
+func (ts *TestServer) Delete(path string, data []byte) (*Response, error) {
+	reqOpts := RequestOptions{
+		Method: celerity.DELETE,
 		Path:   path,
 		Data:   data,
 	}

--- a/celeritytest/celeritytest_test.go
+++ b/celeritytest/celeritytest_test.go
@@ -48,6 +48,81 @@ func TestPost(t *testing.T) {
 	}
 }
 
+func TestPut(t *testing.T) {
+	s := celerity.New()
+	s.Route(celerity.PUT, "/foo", func(c celerity.Context) celerity.Response {
+		req := struct {
+			Param1 string `json:"param1"`
+		}{}
+		c.Extract(&req)
+		return c.R(req)
+	})
+
+	payload := []byte(`
+		{
+			"param1": "123"
+		}
+	`)
+	r, err := Put(s, "/foo", payload)
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	if ok, v := r.AssertString("data.param1", "123"); !ok {
+		t.Errorf("param1 was %s", v)
+	}
+}
+
+func TestPatch(t *testing.T) {
+	s := celerity.New()
+	s.Route(celerity.PATCH, "/foo", func(c celerity.Context) celerity.Response {
+		req := struct {
+			Param1 string `json:"param1"`
+		}{}
+		c.Extract(&req)
+		return c.R(req)
+	})
+
+	payload := []byte(`
+		{
+			"param1": "123"
+		}
+	`)
+	r, err := Patch(s, "/foo", payload)
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	if ok, v := r.AssertString("data.param1", "123"); !ok {
+		t.Errorf("param1 was %s", v)
+	}
+}
+
+func TestDelete(t *testing.T) {
+	s := celerity.New()
+	s.Route(celerity.DELETE, "/foo", func(c celerity.Context) celerity.Response {
+		req := struct {
+			Param1 string `json:"param1"`
+		}{}
+		c.Extract(&req)
+		return c.R(req)
+	})
+
+	payload := []byte(`
+		{
+			"param1": "123"
+		}
+	`)
+	r, err := Delete(s, "/foo", payload)
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	if ok, v := r.AssertString("data.param1", "123"); !ok {
+		t.Errorf("param1 was %s", v)
+	}
+}
+
 func TestRequest(t *testing.T) {
 	s := celerity.New()
 	s.Route(celerity.POST, "/foo", func(c celerity.Context) celerity.Response {


### PR DESCRIPTION
This PR adds a couple more test helpers for Server methods that weren't previously covered, specifically `PUT`/`PATCH`/`DELETE`. The only remaining verb in the current list in `celerity.go` is `OPTIONS` which isn't currently implemented. Additionally, we are currently missing `HEAD`.
Closes #26 #27 