### PR TITLE
Nested scopes are now checked before routes

### DIFF
--- a/route.go
+++ b/route.go
@@ -89,8 +89,15 @@ type LocalPathRoute struct {
 // Match checks if a file exists under the local path
 func (l *LocalPathRoute) Match(method string, path string) (bool, string) {
 	fs := FSAdapter.RootPath(l.LocalPath)
+	if len(path) < len(l.Path) {
+		return false, path
+	}
 	fname := "/" + path[len(l.Path):]
-	if _, err := fs.Stat(fname); os.IsNotExist(err) {
+	stat, err := fs.Stat(fname)
+	if err != nil {
+		return false, path
+	}
+	if stat.Mode().IsDir() {
 		return false, path
 	}
 	return true, ""

--- a/scope.go
+++ b/scope.go
@@ -140,6 +140,12 @@ func (s *Scope) handleWithMiddleware(c Context, middleware []MiddlewareHandler) 
 
 	ph := func(c Context) Response {
 
+		for _, ss := range s.Scopes {
+			if ss.Match(c.Request, c.ScopedPath) {
+				return ss.handleWithMiddleware(c, middleware)
+			}
+		}
+
 		for _, r := range s.Routes {
 			if ok, _ := r.Match(c.Request.Method, c.ScopedPath); ok {
 				c.SetParams(r.RoutePath().GetURLParams(c.Request.URL.Path))
@@ -149,11 +155,6 @@ func (s *Scope) handleWithMiddleware(c Context, middleware []MiddlewareHandler) 
 					h = s.Middleware[i-1](h)
 				}
 				return h(c)
-			}
-		}
-		for _, ss := range s.Scopes {
-			if ss.Match(c.Request, c.ScopedPath) {
-				return ss.handleWithMiddleware(c, middleware)
 			}
 		}
 

--- a/scope_test.go
+++ b/scope_test.go
@@ -305,3 +305,24 @@ func TestFixPath(t *testing.T) {
 		t.Errorf("path not prepended with slash: %s", fixPath(p))
 	}
 }
+
+func TestDeepestRoutePriority(t *testing.T) {
+	s := newScope("/")
+	s.GET("/*", func(c Context) Response {
+		return c.R("catch")
+	})
+	ss := s.Scope("/api")
+	ss.GET("/endpoint", func(c Context) Response {
+		return c.R("api")
+	})
+	req, err := http.NewRequest("GET", "http://example.com/api/endpoint", nil)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	c := RequestContext(req)
+	r := s.Handle(c)
+	rStr := r.Data.(string)
+	if rStr != "api" {
+		t.Errorf("should get api response, got %s", rStr)
+	}
+}

--- a/scope_test.go
+++ b/scope_test.go
@@ -297,6 +297,13 @@ func TestServePath(t *testing.T) {
 			t.Errorf("fileroot not correct: %s", r.Fileroot)
 		}
 	})
+
+	t.Run("root without file", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "http://example.com/test/test.txt", nil)
+		if s.Match(req, "/") {
+			t.Error("should not match non existing file at root")
+		}
+	})
 }
 
 func TestFixPath(t *testing.T) {


### PR DESCRIPTION
Nested scopes are now checked for route matches before individual routes
in the current scope. This was done to allow the "longest" match to
succeed and prevent wildcard routes from catching a route that would
otherwise be completed by a nested route.

Closes #57 