### PR TITLE
Fixed an issue with URL params in scopes

### DIFF
--- a/router.go
+++ b/router.go
@@ -73,6 +73,10 @@ func (rp RoutePath) Match(path string) (bool, string) {
 
 // GetURLParams - Returns a map of url param/values based on the path given.
 func (rp RoutePath) GetURLParams(path string) map[string]string {
+	println(path)
+	if path[0] != '/' {
+		path = "/" + path
+	}
 	params := map[string]string{}
 	pathTokens := strings.Split(path, "/")
 	rpTokens := strings.Split(string(rp), "/")

--- a/scope.go
+++ b/scope.go
@@ -148,7 +148,7 @@ func (s *Scope) handleWithMiddleware(c Context, middleware []MiddlewareHandler) 
 
 		for _, r := range s.Routes {
 			if ok, _ := r.Match(c.Request.Method, c.ScopedPath); ok {
-				c.SetParams(r.RoutePath().GetURLParams(c.Request.URL.Path))
+				c.SetParams(r.RoutePath().GetURLParams(c.ScopedPath))
 				var h RouteHandler
 				h = r.Handle
 				for i := len(s.Middleware); i > 0; i-- {


### PR DESCRIPTION
Params were not returned correctly when a scope was in use.
The param counting was taking the full URL into account instead of the
scoped URL. The scoped URL is now passed to the param extraction
function instead of the full URL.