### PR TITLE
Server CLI Error Handling

### DIFF
--- a/servercli.go
+++ b/servercli.go
@@ -48,7 +48,8 @@ to quickly create a Cobra application.`,
 			server := onRun()
 			vox.PrintProperty("Bound IP", viper.GetString("host"))
 			vox.PrintProperty("Port", viper.GetString("port"))
-			server.Start(hostString)
+			err := server.Start(hostString)
+			vox.Error(err)
 		},
 	}
 


### PR DESCRIPTION
Errors returned from Server.Start() through the CLI will report the
error.