### PR TITLE
Chainable response objects

### DIFF
--- a/context.go
+++ b/context.go
@@ -81,9 +81,19 @@ func (c *Context) R(obj interface{}) Response {
 
 // Respond Respond with an object
 func (c *Context) Respond(obj interface{}) Response {
-	c.Response.StatusCode = 200
 	c.Response.Data = obj
 	return c.Response
+}
+
+// Status returns a response with the set status
+func (c *Context) Status(code int) Response {
+	c.Response.StatusCode = code
+	return c.Response
+}
+
+// S aliases Status
+func (c *Context) S(code int) Response {
+	return c.Status(code)
 }
 
 // F is an alias for the Fail function

--- a/context_test.go
+++ b/context_test.go
@@ -137,3 +137,26 @@ func TestBody(t *testing.T) {
 		t.Errorf("bar value not found: %s", c.Body())
 	}
 }
+
+func TestChainResponses(t *testing.T) {
+	c := NewContext()
+	data := map[string]string{"name": "jim"}
+	r := c.Respond(data).Status(201).MetaValue("test", "123")
+	if r.StatusCode != 201 {
+		t.Errorf("Status code not set to 201 (%d)", r.StatusCode)
+	}
+	if r.Error != nil {
+		t.Errorf("Error not empty: %s", r.Error.Error())
+	}
+	if v, ok := r.Data.(map[string]string); ok {
+		if v["name"] != "jim" {
+			t.Errorf("name not set correctly in data: %s", v["name"])
+		}
+	} else {
+		t.Error("response data not properly set")
+	}
+
+	if r.Meta["test"].(string) != "123" {
+		t.Error("meta not properly set")
+	}
+}

--- a/response.go
+++ b/response.go
@@ -59,3 +59,31 @@ func (r *Response) SetRaw(b []byte) {
 func (r *Response) Raw() []byte {
 	return r.raw
 }
+
+// Status sets the status code for the response
+func (r Response) Status(code int) Response {
+	r.StatusCode = code
+	return r
+}
+
+// Respond sets teh response data
+func (r Response) Respond(data interface{}) Response {
+	r.Data = data
+	return r
+}
+
+// R aliases Respond
+func (r Response) R(data interface{}) Response {
+	return r.Respond(data)
+}
+
+// S aliases Status
+func (r Response) S(code int) Response {
+	return r.Status(code)
+}
+
+// MetaValue sets the metadata key for the response
+func (r Response) MetaValue(k string, v interface{}) Response {
+	r.Meta[k] = v
+	return r
+}

--- a/servercli.go
+++ b/servercli.go
@@ -73,9 +73,11 @@ to quickly create a Cobra application.`,
 		Long:  `Prints a list of all registered routes in the application.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			server := onRun()
-			vox.Println("All server routes:\n")
+			vox.Println("All server routes:")
+			vox.Println("")
 			printScope(server.Router.Root)
-			vox.Println("\n")
+			vox.Println("")
+			vox.Println("")
 		},
 	}
 	rootCmd.AddCommand(routesCmd)


### PR DESCRIPTION
Response configuration can now be done through function chaining.

C.Respond(data{}).Status(201)

To accomplish this functions that return a new response were added to
response itself and a status method was added to context to return a
response with its status set.

Closes #28 