### PR TITLE
Added context responder for handled routes

### DIFF
--- a/context.go
+++ b/context.go
@@ -101,6 +101,16 @@ func (c *Context) F(err error) Response {
 	return c.Fail(err)
 }
 
+// Handled marks the response as externally handled this will cause it to not be
+// further processed by the framework so it can be fully processed by the route
+// handler or middleware. This will also clear any values from the context's
+// response object and reset the status code to 200.
+func (c *Context) Handled() Response {
+	c.Response = NewResponse()
+	c.Response.Handled = true
+	return c.Response
+}
+
 // Body returns the request body
 func (c *Context) Body() []byte {
 	if len(c.data) == 0 {

--- a/middleware/request_logger.go
+++ b/middleware/request_logger.go
@@ -30,12 +30,10 @@ type RequestLoggerData struct {
 // NewLoggerConfig creates a default configuration for RequestLoggerConfig.
 func NewLoggerConfig() RequestLoggerConfig {
 	return RequestLoggerConfig{
-		ConsoleTemplate: `
-{{ .C.RequestID }} - [{{.Now.Format "1/2/2006 15:04:05"}}] - {{ .C.Request.Method }} {{.URL.Path}} ({{ .Duration }}) - {{ .R.StatusCode }}  {{ .R.StatusText }}
-{{ if eq .R.Success false -}}
+		ConsoleTemplate: `{{ .C.RequestID }} - [{{.Now.Format "1/2/2006 15:04:05"}}] - {{ .C.Request.Method }} {{.URL.Path}} ({{ .Duration }}) - {{ .R.StatusCode }}  {{ .R.StatusText -}}
+{{ if eq .R.Success false }}
 	ERROR: {{ .R.Error }}
-{{- end }}
-`,
+{{- end }}`,
 	}
 }
 

--- a/router.go
+++ b/router.go
@@ -73,7 +73,6 @@ func (rp RoutePath) Match(path string) (bool, string) {
 
 // GetURLParams - Returns a map of url param/values based on the path given.
 func (rp RoutePath) GetURLParams(path string) map[string]string {
-	println(path)
 	if path[0] != '/' {
 		path = "/" + path
 	}
@@ -157,7 +156,7 @@ func (l *LocalFileRoute) Handle(c Context) Response {
 	fpath := filepath.Dir(l.LocalPath)
 
 	serveFile(c.Writer, fpath, fname)
-	return Response{Handled: true}
+	return c.Handled()
 }
 
 // RoutePath returns the route path for the route.
@@ -195,7 +194,7 @@ func (l *LocalPathRoute) Handle(c Context) Response {
 	fname := c.ScopedPath[len(l.Path):]
 	fpath := l.LocalPath
 	serveFile(c.Writer, fpath, fname)
-	return Response{Handled: true}
+	return c.Handled()
 }
 
 // RoutePath returns the routepath for the route

--- a/servercli.go
+++ b/servercli.go
@@ -48,6 +48,7 @@ to quickly create a Cobra application.`,
 			server := onRun()
 			vox.PrintProperty("Bound IP", viper.GetString("host"))
 			vox.PrintProperty("Port", viper.GetString("port"))
+			vox.Println("")
 			err := server.Start(hostString)
 			vox.Error(err)
 		},


### PR DESCRIPTION
Context now have a c.Handled() helper which is used to mark a route
fully processed by the route handler.

Static route handlers have been changed to use the Handled helper
instead of manufacturing their own response.